### PR TITLE
feat: add database maintenance CLI commands (cleanup, health, stats)

### DIFF
--- a/docs/informes/CROSS-ANALYSIS-GSD-FORK-AGENT.md
+++ b/docs/informes/CROSS-ANALYSIS-GSD-FORK-AGENT.md
@@ -1,0 +1,292 @@
+# Informe Técnico: Análisis Cruzado GSD vs fork_agent
+
+## Resumen Ejecutivo
+
+Este informe técnico documenta el análisis cruzado realizado entre el proyecto **get-shit-done (GSD)** y el sistema **fork_agent**, comparando conceptos, patrones arquitectónicos y decisiones de diseño documentadas en los repositorio. El objetivo principal de este análisis informes existentes del es identificar brechas entre la implementación actual de fork_agent y las propuestas conceptuales de GSD, proporcionando recomendaciones concretas para futuras implementaciones.
+
+El análisis revela que fork_agent presenta una arquitectura DDD robusta basada en Python con patrones de resiliencia bien implementados (CircuitBreaker, Retry, DLQ), mientras que GSD ofrece un enfoque de meta-prompting con énfasis en la ingeniería de contexto y el desarrollo dirigido por especificaciones. Las brechas identificadas abarcan desde la gestión del estado del workflow hasta la definición de agentes como configuración, con oportunidades significativas de mejora en la preservación de decisiones del usuario y la verificación sistemática.
+
+---
+
+## 1. Objetivos del Análisis Cruzado
+
+### 1.1 Propósito General
+
+El análisis cruzado tiene como propósito fundamental establecer una puente conceptual entre dos aproximaciones diferentes pero complementarias para la orquestación de agentes AI. GSD, con su enfoque en meta-prompting y spec-driven development, ofrece patrones transferibles que podrían fortalecer la arquitectura de fork_agent, particularmente en áreas donde los informes de decisión identifican brechas críticas.
+
+### 1.2 Objetivos Específicos
+
+Los objetivos específicos de este análisis incluyen la identificación precisa de brechas entre lo implementado en fork_agent y lo propuesto por GSD, priorizadas según el impacto técnico y la complejidad de implementación. Se busca establecer un mapeo entre los conceptos de GSD y las brechas documentadas en DECISION-GAPS.md, cuantificando el nivel de alineación arquitectónica actual. El análisis también pretende proporcionar recomendaciones priorizadas con justificación técnica detallada, y generar un documento de referencia para futuras implementaciones que incorpore los patrones valiosos de GSD.
+
+### 1.3 Alcance del Análisis
+
+El alcance de este análisis comprende la comparación de siete conceptos principales de GSD contra la arquitectura, decisiones de diseño y brechas documentadas en fork_agent. Los documentos de referencia incluyen ARCHITECTURE.md como referencia arquitectónica, DECISION-GAPS.md para las brechas identificadas, EXPLORATION-DECISION-IN laPUTS.md para evidencia de pruebas y cobertura, y GSD-IDEAS-FORK-AGENT.md para las ideas de transferencia ya identificadas.
+
+---
+
+## 2. Metodología Utilizada
+
+### 2.1 Enfoque de Análisis
+
+La metodología empleada sigue un enfoque de análisis documental comparativo con cuatro fases principales. La primera fase consistió en la recopilación sistemática de documentos, donde se identificaron y organizaron todos los informes relevantes del directorio docs/informes/. La segunda fase implicó la extracción de conceptos clave de GSD, incluyendo los once agentes especializados, los patrones de diseño como meta-prompting y context engineering, y los comandos CLI disponibles.
+
+La tercera fase correspondió al mapeo de brechas, donde cada concepto de GSD se relacionó con las brechas documentadas en DECISION-GAPS.md y los gaps de workflow identificados. Finalmente, la cuarta fase consistió en la priorización de mejoras mediante la aplicación de criterios técnicos que consideran el impacto en la estabilidad del sistema, la complejidad de implementación, y la alineación con la arquitectura existente.
+
+### 2.2 Criterios de Priorización
+
+La priorización de las mejoras identificadas se realizó siguiendo tres criterios principales. El primero es el impacto técnico, donde se evaluó la gravedad de la brecha y su efecto en la estabilidad y seguridad del sistema. El segundo criterio es la complejidad de implementación, considerando el esfuerzo estimado en horas y las dependencias con otros componentes. El tercer criterio es la viabilidad de transferencia, evaluando qué tan directamente se pueden adaptar los patrones de GSD a la arquitectura Python/DDD de fork_agent.
+
+### 2.3 Limitaciones del Análisis
+
+Es importante reconocer las limitaciones inherentes a este análisis. Primero, GSD está implementado en Node.js mientras fork_agent utiliza Python, lo que introduce diferencias arquitectónicas fundamentales. Segundo, GSD utiliza archivos locales para persistencia mientras fork_agent emplea SQLite con WAL. Tercero, el análisis se basa en documentación, no en código fuente vivo de GSD, lo que introduce potenciales imprecisiones en la interpretación de patrones.
+
+---
+
+## 3. Hallazgos Principales
+
+### 3.1 Análisis Comparativo de Arquitecturas
+
+La comparación arquitectónica revela diferencias fundamentales entre los dos sistemas que impactan directamente la transferibilidad de conceptos. GSD adopta una arquitectura de meta-prompting donde los agentes son prompts estructurados en markdown con frontmatter YAML, mientras fork_agent implementa una arquitectura DDD tradicional con agentes codificados en Python. Esta diferencia arquitectónica es fundamental para entender qué patrones pueden transferirse y cuáles requieren adaptación significativa.
+
+En términos de persistencia, GSD utiliza archivos locales (CLAUDE.md) para mantener contexto entre sesiones, contrastando con el enfoque de fork_agent basado en SQLite con FTS5 para búsqueda full-text. La diferencia en modelos de datos tiene implicaciones significativas para la implementación de características como context fidelity y preservación de decisiones de usuario.
+
+Respecto a la separación de responsabilidades, GSD implementa once agentes especializados (planner, executor, verifier, debugger, researchers) como prompts separados, mientras fork_agent centraliza la lógica en AgentManager con uso de CircuitBreaker para resiliencia. Esta diferencia sugiere oportunidades para introducir especialización de agentes en fork_agent sin abandonar su arquitectura existente.
+
+### 3.2 Evidencia Específica de Documentos Comparados
+
+#### 3.2.1 De ARCHITECTURE.md
+
+El documento de arquitectura de fork_agent establece las bases del sistema actual. La estructura de capas DDD (Domain, Application, Infrastructure, Interfaces) proporciona un marco sólido para la introducción de nuevos patrones. El sistema de workflow con fases (PLANNING → OUTLINED → EXECUTING → EXECUTED → VERIFYING → VERIFIED → SHIPPING → SHIPPED) ofrece puntos de extensión naturales para incorporar conceptos de GSD como goal-backward planning y verification sistemática.
+
+La implementación actual del workflow en state.py muestra una separación clara entre estados (PlanState, ExecuteState, VerifyState), pero carece de versionado de schema según lo identificado en GAP-WF-001. Esta brecha es particularmente relevante para la transferencia de conceptos de GSD que modifican la estructura del estado.
+
+#### 3.2.2 De DECISION-GAPS.md
+
+El documento de brechas identifica 24 brechas de decisión clasificadas por prioridad. Las brechas de mayor prioridad (P0) incluyen State Schema Versioning (GAP-WF-001), Phase Skip Prevention (GAP-WF-003), Migration System (GAP-DB-001), Idempotency Mechanism (GAP-DB-002), y Hook Criticality Levels (GAP-HK-001). Estas brechas representan áreas donde los conceptos de GSD podrían proporcionar soluciones o inspiración directa.
+
+Particularmente relevante es la brecha GAP-WF-002 (State Validation), que se alinea directamente con el concepto de verificación sistemática de GSD. Mientras fork_agent carece de validación de estado contra especificaciones explícitas, GSD implementa un agente dedicado (gsd-verifier) que compara evidencia contra requisitos.
+
+#### 3.2.3 De EXPLORATION-DECISION-INPUTS.md
+
+El informe de exploración proporciona evidencia cuantitativa sobre la cobertura de pruebas y el estado actual del sistema. Con 63 archivos de prueba y aproximadamente 802 pruebas totales, el sistema tiene una cobertura razonable pero con brechas críticas. Particularmente relevante es la ausencia de pruebas unitarias para el workflow state machine, lo que representa un riesgo para la introducción de nuevos patrones.
+
+La evidencia sobre resiliencia muestra dos implementaciones diferentes de CircuitBreaker con configuraciones distintas (TmuxCircuitBreaker: threshold=3, recovery=30s; AgentManager: threshold=5, recovery=60s), lo que indica inconsistencias que deberían abordarse antes de implementar patrones adicionales de GSD.
+
+#### 3.2.4 De GSD-IDEAS-FORK-AGENT.md
+
+Este documento ya identifica siete ideas de GSD transferibles a fork_agent, proporcionando un punto de partida valioso para el análisis. Las ideas incluyen Context Fidelity, Goal-Backward Planning, Verificación Sistemática, Meta-Prompting como Configuración, Phase Research, Context Rot Prevention, y Commands as Prompts. Cada idea se mapea a brechas específicas de fork_agent, estableciendo una base para la priorización.
+
+---
+
+## 4. Brechas Identificadas
+
+### 4.1 Brechas de Workflow y Estado
+
+#### GAP-WF-001: State Schema Versioning
+
+El sistema de estado actual de fork_agent carece de versionado de schema, lo que implica que cualquier cambio en la estructura de PlanState, ExecuteState o VerifyState podría corromper workflows existentes. Esta brecha es directamente abordable mediante la incorporación del patrón de Context Fidelity de GSD, que enfatiza la preservación de decisiones a través del workflow.
+
+La implementación actual en state.py no incluye campo schema_version, y los métodos from_json() carecen de lógica de migración. La brecha representa un riesgo P0 según DECISION-GAPS.md, con potencial de romper workflows existentes ante cualquier actualización.
+
+#### GAP-WF-002: State Validation
+
+Actualmente, fork_agent valida la existencia de archivos de estado pero no su contenido contra especificaciones explícitas. El comando verify corre tests pero no valida contra specs explícitos ni recoleta evidencia estructurada. Esta brecha se alinea directamente con el concepto de Verificación Sistemática de GSD, donde un agente dedicado compara evidencia contra requisitos.
+
+La implementación de un sistema de validación de estado requeriría la definición de esquemas de validación para cada fase del workflow, algo que GSD logra mediante sus agentes especializados con prompts estructurados.
+
+#### GAP-WF-003: Phase Skip Prevention
+
+Aunque la CLI de workflow enforce la secuencia de fases, no hay validación a nivel de API o Use Cases. Esto significa que llamadas directas a los métodos de workflow podrían saltar fases. El enfoque de GSD de agentes como prompts estructurados con instrucciones específicas para cada fase ofrece un modelo para implementar protección más robusta.
+
+### 4.2 Brechas de Agentes y Orquestación
+
+#### GAP-PT-001: Multi-Agent Platform Support
+
+La arquitectura actual de fork_agent tiene dependencias directas con TmuxAgent en AgentManager, lo que dificulta la adición de nuevas plataformas de agentes. GSD resuelve esto mediante agentes definidos como prompts con metadatos (incluyendo tools permitidas), lo que permite abstracción completa entre definición y ejecución.
+
+La sugerencia de GSD-IDEAS-FORK-AGENT.md de crear un sistema de agent definitions como archivos de configuración (JSON/YAML) con tools configurables representa una solución directa a esta brecha. El código Python ejecutaría sin definir comportamiento, logrando separación de concerns.
+
+### 4.3 Brechas de Contexto y Memoria
+
+#### Context Rot Prevention (Nuevo)
+
+El documento GSD-IDEAS-FORK-AGENT.md identifica una brecha no cubierta por DECISION-GAPS.md: la falta de sistema de resumen o compresión de contexto. Mientras fork_agent tiene memoria SQLite con FTS5, no hay mecanismo para resumir o condensar contexto cuando la ventana se llena.
+
+Esta brecha representa una oportunidad de innovación, ya que ni GSD ni fork_agent tienen implementación completa de esta característica. La propuesta de implementar context summarization con detección de ventana llena, generación de resúmenes condensados, y retención solo de contexto accionable es técnicamente viable dado el sistema de memoria existente.
+
+### 4.4 Brechas de Investigación de Contexto
+
+#### Phase Research (GSD)
+
+GSD implementa investigadores de contexto (gsd-phase-researcher, gsd-project-researcher, gsd-codebase-mapper) que analizan el codebase antes de planificar o ejecutar. El workflow actual de fork_agent (outline → execute → verify → ship) carece de fase de investigación obligatoria.
+
+La implementación de una fase de research requeriría integración con el sistema de workspace detection existente (workspace_detector.py) y extensión del workflow state para incluir contexto investigado. Esta brecha se alinea con GAP-WF-001 (State Schema Versioning) ya que requeriría extensiones al schema de estado.
+
+---
+
+## 5. Oportunidades de Mejora Priorizadas
+
+### 5.1 Prioridad Alta (Inmediata - 1 Sprint)
+
+#### Oportunidad 1: User Decisions Tracking
+
+Esta oportunidad aborda directamente GAP-WF-002 y GAP-WF-003 mediante la implementación de un sistema de seguimiento de decisiones del usuario en el workflow state. La complejidad se cataloga como media con impacto alto en la utilidad del sistema.
+
+La implementación propuesta consiste en añadir una clase UserDecision al módulo de estado del workflow, con campos para key, value, status (locked/deferred/discretion), y opcionalmente rationale. El estado del workflow se extendería para incluir un diccionario de decisiones, y los comandos CLI modificarían su comportamiento basado en el estado de cada decisión.
+
+El beneficio principal es la preservación de decisiones del usuario a través de las fases del workflow, evitando la degradación de calidad que ocurre cuando el contexto se pierde entre interacciones. Esta característica es fundamental para el concepto de Context Fidelity de GSD.
+
+```python
+# Propuesta de implementación
+from dataclasses import dataclass
+from typing import Literal
+
+@dataclass
+class UserDecision:
+    key: str
+    value: str
+    status: Literal["locked", "deferred", "discretion"]
+    rationale: str | None = None
+
+@dataclass
+class WorkflowState:
+    # ... campos existentes ...
+    decisions: dict[str, UserDecision] = field(default_factory=dict)
+```
+
+#### Oportunidad 2: Goal Analysis en Outline
+
+Esta oportunidad mejora la calidad de los planes generados mediante la incorporación de análisis de objetivo en la fase de outline. La complejidad es alta pero el impacto en la calidad de planificación justifica la prioridad.
+
+El enfoque propuesto añade una fase de goal analysis que precede a la generación de tareas: definición del resultado final esperado, derivación de requisitos mínimos (must-haves), identificación de dependencias entre tareas, y generación de plan desde el objetivo hacia atrás. Esta metodología goal-backward de GSD填补 la brecha de State Validation al hacer explícito el objetivo desde el inicio.
+
+La implementación requeriría extensión del comando outline para aceptar y procesar información de objetivo, con almacenamiento en PlanState para referencia durante ejecución y verificación.
+
+### 5.2 Prioridad Media (Corto Plazo - 2 Sprints)
+
+#### Oportunidad 3: Evidence Collection para Verificación
+
+Esta oportunidad aborda GAP-WF-002 mediante la separación de la verificación en dos pasos: recolección de evidencia y validación contra specifications. La complejidad es media con impacto directo en la confiabilidad del workflow.
+
+La implementación consistiría en crear un módulo de evidence collection que recopile outputs, resultados de tests, y logs durante la fase de ejecución. Luego, un validador de specs compararía la evidencia contra requisitos explícitos, reportando brechas de forma estructurada similar al agente gsd-verifier de GSD.
+
+Esta mejora填补 también GAP-WF-003 (Phase Skip Prevention) porque hace explícitos los requisitos que deben cumplirse antes de avanzar a la siguiente fase.
+
+#### Oportunidad 4: Phase Research Integration
+
+Esta oportunidad填补 GAP-WF-001 mediante la adición de contexto auto-descubierto al workflow. La complejidad es media con impacto en la calidad de decisiones de planificación.
+
+La implementación proposed integraría auto-detección de stack tecnológico, análisis de estructura del proyecto, identificación de skills y convenciones disponibles, y generación de contexto para el planner. El sistema de workspace detection existente proporciona una base sobre la cual construir esta característica.
+
+### 5.3 Prioridad Baja (Largo Plazo)
+
+#### Oportunidad 5: Agent Definitions as Config
+
+Esta oportunidad aborda GAP-PT-001 mediante la migración de agentes de código Python a configuración JSON/YAML. La complejidad es alta pero el impacto en mantenibilidad y extensibilidad es significativo.
+
+La implementación requeriría crear un sistema de definición de agentes donde los prompts, herramientas permitidas, y comportamientos se definan como configuración. El código Python existente de AgentManager se modificaría para cargar estas definiciones y ejecutarlas, separando completamente la definición del comportamiento de la implementación.
+
+Esta separación permite añadir nuevos agentes sin modificar código, aligning con el enfoque de GSD de meta-prompting pero adaptado a la arquitectura Python de fork_agent.
+
+#### Oportunidad 6: Context Summarization
+
+Esta oportunidad representa un nuevo feature no cubierto por brechas actuales. La complejidad es alta ya que requiere técnicas de generación de resúmenes y gestión de ventanas de contexto.
+
+La implementación propuesta detectaría cuando la ventana de contexto se llena, generaría resúmenes condensados del trabajo previo, y retendría solo contexto accionable para la fase actual. Esta característica es especialmente relevante para sesiones largas donde el contexto acumulado degrade la calidad de las respuestas.
+
+---
+
+## 6. Recomendaciones para Futuras Implementaciones
+
+### 6.1 Recomendaciones de Arquitectura
+
+#### Recomendación 1: Adoptar Patrón de Agentes Especializados
+
+En lugar de un AgentManager monolítico, se recomienda introducir especialización de agentes similar al modelo de GSD. Esto no requiere abandonar la arquitectura Python, sino extender el sistema de agentes para incluir comportamientos especializados para diferentes fases del workflow.
+
+La implementación inicial debería incluir un agente de verificación separado del agente de ejecución, siguiendo el patrón de GSD donde el executor no se verifica a sí mismo. Esta separación mejora la confiabilidad al introducir verificación independiente.
+
+#### Recomendación 2: Implementar Versionado de Schema
+
+Antes de introducir nuevas características que modifiquen el estado del workflow, es crítico implementar versionado de schema. Esta recomendación aborda GAP-WF-001 que se identifica como P0 en DECISION-GAPS.md.
+
+La implementación debería incluir campo schema_version en todos los estados, lógica de migración en los métodos from_json(), y tests de compatibilidad hacia adelante y atrás. Esta base permitirá evolución segura del sistema de estado.
+
+#### Recomendación 3: Separar Definición de Ejecución de Agentes
+
+La迁移 hacia agentes definidos como configuración (Oportunidad 5) debería planificarse desde el inicio con una estrategia de transición. Se recomienda mantener el AgentManager existente como capa de ejecución, con un nuevo módulo de AgentDefinitionLoader que cargue configuraciones y las traduzca a comportamiento ejecutable.
+
+Esta separación permite introducir el paradigma de meta-prompting de GSD sin sacrificar la estabilidad del sistema actual.
+
+### 6.2 Recomendaciones de Processo
+
+#### Recomendación 4: Implementar Pruebas de Estado de Workflow
+
+El informe de exploración identifica ausencia de pruebas unitarias para workflow state machine. Antes de introducir nuevos patrones de GSD, es crítico implementar cobertura de pruebas para el sistema de estado.
+
+Las pruebas deberían cubrir validación de schema, transiciones de fase, y comportamiento de gates. Esta cobertura asegurará que las nuevas implementaciones no rompan funcionalidad existente.
+
+#### Recomendación 5: Establecer Métricas de Contexto
+
+Se recomienda implementar métricas de monitoreo de tamaño de contexto para informar la implementación futura de context summarization. Las métricas deberían incluir tokens por sesión, crecimiento de contexto por fase, y correlación con calidad de outputs.
+
+Estas métricas proporcionarán datos empíricos para validar la necesidad y efectividad de características de gestión de contexto.
+
+### 6.3 Recomendaciones Técnicas Específicas
+
+#### Recomendación 6: Extender hooks.json para Criticalidad
+
+GAP-HK-001 identifica la necesidad de niveles de criticidad en hooks. La implementación debería añadir campo critical: bool al schema de hooks.json, con comportamiento diferenciado: hooks críticos abortan workflow en caso de fallo, mientras hooks no-críticos registran y continúan.
+
+Esta extensión es de complejidad baja y impacto alto en la confiabilidad del sistema de hooks.
+
+#### Recomendación 7: Unificar Configuraciones de CircuitBreaker
+
+La evidencia en EXPLORATION-DECISION-INPUTS.md revela dos implementaciones de CircuitBreaker con configuraciones diferentes. Se recomienda unificar estas configuraciones o documentar claramente las razones de las diferencias.
+
+La unificación reduce complejidad y mejora mantenibilidad del sistema de resiliencia.
+
+---
+
+## 7. Matriz de Trazabilidad GSD-Gaps
+
+La siguiente matriz establece la trazabilidad entre conceptos de GSD y brechas de fork_agent:
+
+| Concepto GSD | Brecha fork_agent | Prioridad | Complejidad | Estado |
+|--------------|-------------------|-----------|-------------|--------|
+| Context Fidelity | GAP-WF-002 (State Validation) | P1 | Media | Oportunidad 1 |
+| Goal-Backward Planning | GAP-WF-001 (Schema Versioning) | P1 | Alta | Oportunidad 2 |
+| Verificación Sistemática | GAP-WF-002, GAP-WF-003 | P1 | Media | Oportunidad 3 |
+| Meta-Prompting as Config | GAP-PT-001 (Multi-Platform) | P2 | Alta | Oportunidad 5 |
+| Phase Research | GAP-WF-001 (Schema) | P2 | Media | Oportunidad 4 |
+| Context Rot Prevention | (Nuevo) | P3 | Alta | Oportunidad 6 |
+| Commands as Prompts | (Arquitectural) | N/A | Baja | Adoptado implícitamente |
+
+---
+
+## 8. Conclusiones
+
+El análisis cruzado entre GSD y fork_agent revela un panorama de oportunidades de mejora fundamentado en la transferencia de patrones probados. GSD, con su éxito demostrado (20,000+ stars), ofrece conceptos valiosos que pueden adaptarse a la arquitectura DDD de fork_agent.
+
+Las brechas más críticas (State Schema Versioning, State Validation, Phase Skip Prevention) tienen soluciones directas inspiradas en GSD, particularmente en los conceptos de Context Fidelity, Goal-Backward Planning, y Verificación Sistemática. La implementación de estas mejoras fortalecerá la confiabilidad y utilidad del sistema de workflow de fork_agent.
+
+La arquitectura DDD de fork_agent proporciona una base sólida para la introducción de estos patrones. La separación de capas (Domain, Application, Infrastructure, Interfaces) permite implementar mejoras incrementales sin comprometer la estabilidad existente. La recomendación principal es proceder con las oportunidades de prioridad alta (User Decisions Tracking y Goal Analysis) mientras se establece la infraestructura necesaria (versionado de schema, pruebas de estado) para soportar las mejoras de prioridad media y baja.
+
+El resultado de este análisis es un roadmap priorizado de mejoras que alinea la evolución de fork_agent con patrones probados en la industria, manteniendo la identidad arquitectónica del proyecto mientras incorpora lo mejor de la aproximación de GSD al desarrollo dirigido por especificaciones.
+
+---
+
+## Referencias
+
+- [1] docs/informes/ARCHITECTURE.md - Arquitectura de referencia de fork_agent
+- [2] docs/informes/DECISION-GAPS.md - Catálogo de brechas de decisión
+- [3] docs/informes/EXPLORATION-DECISION-INPUTS.md - Evidencia de pruebas y cobertura
+- [4] docs/informes/GSD-IDEAS-FORK-AGENT.md - Ideas de transferencia de GSD
+- [5] docs/informes/GSD-ANALYSIS.md - Análisis del proyecto get-shit-done
+- [6] GSD Repository - https://github.com/gsd-build/get-shit-done
+
+---
+
+*Documento generado: 2026-02-25*
+*Análisis cruzado: GSD vs fork_agent*
+*Tipo: Informe técnico estructurado*

--- a/docs/informes/GSD-ANALYSIS.md
+++ b/docs/informes/GSD-ANALYSIS.md
@@ -1,0 +1,256 @@
+# Análisis: get-shit-done (GSD)
+
+**Repositorio:** https://github.com/gsd-build/get-shit-done  
+**Stars:** 20,024+  
+**Versión:** 1.21.0  
+**Fecha de análisis:** 2026-02-25
+
+---
+
+## 1. Overview
+
+**Get Shit Done (GSD)** es un sistema de **meta-prompting, context engineering y spec-driven development** para agentes AI como Claude Code, OpenCode, Gemini CLI y Codex.
+
+Fue creado por **TÂCHES** para resolver el problema del "context rot" — la degradación de calidad que ocurre cuando Claude llena su ventana de contexto.
+
+### Problema que resuelve
+
+- **Vibecoding** tradicional produce código inconsistente que se desmorona a escala
+- GSD proporciona la capa de ingeniería de contexto que hace a Claude Code confiable
+- Enfocado en desarrolladores individuales, no en equipos enterprise
+
+### Filosofía
+
+> *"La complejidad está en el sistema, no en tu workflow."*
+
+- Sin ceremonias enterprise (sprints, story points, syncs, retros)
+- Enfoque en obtener resultados efectivos con mínima fricción
+
+---
+
+## 2. Arquitectura del Sistema
+
+### 2.1 Componentes Principales
+
+```
+get-shit-done/
+├── agents/              # Agentes especializados (meta-prompts)
+├── commands/gsd/        # Comandos CLI (/gsd:*)
+├── get-shit-done/       
+│   ├── bin/            # Scripts de instalación
+│   ├── references/     # Referencias de contexto
+│   ├── templates/      # Plantillas para proyectos
+│   └── workflows/      # Workflows predefinidos
+├── hooks/              # Git hooks
+├── scripts/            # Scripts de build
+└── tests/             # Tests
+```
+
+### 2.2 Agentes Especializados (11 agentes)
+
+| Agente | Descripción |
+|--------|-------------|
+| `gsd-planner` | Crea planes ejecutables con breakdown de tareas y análisis de dependencias |
+| `gsd-executor` | Implementa planes generados por el planner |
+| `gsd-verifier` | Verifica el trabajo completado contra specs |
+| `gsd-debugger` | Debugging sistemático con enfoque científico |
+| `gsd-phase-researcher` | Investigación de contexto para fases |
+| `gsd-project-researcher` | Investigación de contexto a nivel proyecto |
+| `gsd-codebase-mapper` | Mapeo de arquitectura y estructura del codebase |
+| `gsd-plan-checker` | Valida planes antes de ejecución |
+| `gsd-roadmapper` | Crea roadmap de alto nivel |
+| `gsd-integration-checker` | Verifica integraciones |
+| `gsd-research-synthesizer` | Sintetiza investigaciones |
+
+### 2.3 Comandos CLI (30+ comandos)
+
+```
+/gsd:new-project    - Crear nuevo proyecto
+/gsd:plan-phase    - Planificar fase
+/gsd:execute-phase - Ejecutar fase
+/gsd:verify-work   - Verificar trabajo
+/gsd:debug         - Modo debug sistemático
+/gsd:research-phase - Investigar contexto
+/gsd:add-phase     - Añadir nueva fase
+/gsd:new-milestone - Crear milestone
+/gsd:map-codebase  - Mapear estructura
+... (30+ más)
+```
+
+---
+
+## 3. Tecnologías y Dependencias
+
+### 3.1 Stack Técnico
+
+| Tecnología | Uso |
+|------------|-----|
+| **Node.js** | Runtime (>=16.7.0) |
+| **esbuild** | Bundling de hooks |
+| **npm** | Package manager |
+
+### 3.2 Dependencias
+
+```json
+{
+  "devDependencies": {
+    "esbuild": "^0.24.0"
+  }
+}
+```
+
+**Notable:** El paquete NO tiene dependencias de runtime — es extremadamente lightweight.
+
+### 3.3 Plataformas Soportadas
+
+- Claude Code
+- OpenCode
+- Gemini CLI
+- Codex CLI
+
+---
+
+## 4. Patrones de Diseño
+
+### 4.1 Meta-Prompting
+
+Cada agente es un **prompt estructurado** con:
+- Frontmatter YAML para metadatos (name, description, tools, color)
+- Secciones XML (`<role>`, `<project_context>`, `<context_fidelity>`, etc.)
+- Instrucciones específicas para cada tipo de tarea
+
+### 4.2 Context Engineering
+
+```
+┌─────────────────────────────────────────┐
+│           CONTEXT.md                     │
+├─────────────────────────────────────────┤
+│ • User decisions (locked/deferred)      │
+│ • Project context                       │
+│ • Skills del proyecto                   │
+│ • Previous work state                   │
+└─────────────────────────────────────────┘
+```
+
+### 4.3 Spec-Driven Development
+
+1. **User describe** → Qué quiere construir
+2. **GSD extract** → Extrae todo lo necesario
+3. **Claude build** → Implementa con verificación continua
+4. **GSD verify** → Verifica contra specs
+
+### 4.4 Goal-Backward Planning
+
+- Planificar desde el resultado deseado hacia atrás
+- Derivar "must-haves" desde el objetivo final
+- Análisis de dependencias entre tareas
+
+---
+
+## 5. Comparativa con fork_agent
+
+| Aspecto | fork_agent | get-shit-done |
+|---------|------------|---------------|
+| **Arquitectura** | DDD (Python/Typer) | Meta-prompting (Node.js) |
+| **Persistencia** | SQLite | Archivos locales |
+| **Agentes** | AgentManager (Python) | Prompts markdown |
+| **CLI** | Typer (Python) | Claude Code commands |
+| **Testing** | pytest | node --test |
+| **Scope** | Memoria + Orquestación | Spec-driven development |
+
+### Similitudes
+
+- Ambos resuelven problemas de contexto en agentes AI
+- Orquestación de subagentes/tareas
+- Sistema de hooks para automatización
+- Enfoque en developer experience
+
+### Diferencias Clave
+
+- **GSD**: Enfoque en workflow de desarrollo (plan → execute → verify)
+- **fork_agent**: Enfoque en memoria persistente y coordinación de agentes
+
+---
+
+## 6. Instalación y Uso
+
+### Instalación
+
+```bash
+npx get-shit-done-cc@latest
+```
+
+El instalador pregunta:
+1. **Runtime** — Claude Code, OpenCode, Gemini, Codex
+2. **Location** — Global o local
+
+### Verificación
+
+- Claude Code / Gemini: `/gsd:help`
+- OpenCode: `/gsd-help`
+- Codex: `$gsd-help`
+
+---
+
+## 7.Insights para fork_agent
+
+### 7.1 Patrones Adoptar
+
+1. **Frontmatter en prompts** — Metadatos estructurados para agentes
+2. **Context fidelity** — Preservar decisiones del usuario a través del workflow
+3. **Goal-backward planning** — Planificar desde el resultado
+4. **Verificación sistemática** — Agentes dedicados a verificar trabajo
+5. **Phase-based workflow** — Dividir trabajo en fases ejecutables
+
+### 7.2 Estructura de Agentes GSD
+
+```markdown
+---
+name: gsd-planner
+description: Creates executable phase plans...
+tools: Read, Write, Bash, Glob, Grep, WebFetch, mcp__context7__*
+color: green
+---
+
+<role>
+You are a GSD planner...
+</role>
+
+<project_context>
+Before planning, discover project context...
+</project_context>
+
+<context_fidelity>
+## CRITICAL: User Decision Fidelity
+...
+</context_fidelity>
+
+<philosophy>
+## Solo Developer + Claude Workflow
+...
+</philosophy>
+```
+
+### 7.3 Estado Persistente
+
+GSD usa `CLAUDE.md` (o `.claude.md`) para mantener contexto entre sesiones.
+
+---
+
+## 8. Conclusión
+
+**get-shit-done** es un sistema elegante y efectivo para hacer que agentes AI construyan software de manera confiable. Su éxito (20k+ stars) se basa en:
+
+1. **Simplicidad aparente** — El usuario ve few commands, no complejidad
+2. **Profundidad interna** — Context engineering sofisticado debajo
+3. **Enfoque en resultados** — Sin enterprise theater
+4. **Multi-plataforma** — Soporta múltiples runtimes de AI
+
+Para **fork_agent**, GSD ofrece patrones valiosos especialmente en:
+- Diseño de agentes como prompts estructurados
+- Workflow de verificación sistemática
+- Preservación de contexto y decisiones de usuario
+
+---
+
+*Análisis generado el 2026-02-25*

--- a/docs/informes/GSD-IDEAS-FORK-AGENT.md
+++ b/docs/informes/GSD-IDEAS-FORK-AGENT.md
@@ -1,0 +1,214 @@
+# Ideas de GSD para fork_agent
+## Enfoque: Conceptos, no productos
+
+> Este documento identifica ideas concepto de GSD que podrían mejorar fork_agent.
+> No es un copy-paste, sino una síntesis de patrones transferibles.
+
+---
+
+## 1. Context Fidelity (Preservar Decisiones del Usuario)
+
+### El Concepto
+GSD tiene un sistema explícito para preservar decisiones del usuario a través del workflow:
+
+```
+<context_fidelity>
+## CRITICAL: User Decision Fidelity
+
+1. **Locked Decisions** — Implementar EXACTAMENTE como el usuario decidió
+2. **Deferred Ideas** — NO implementar ideas diferidas por el usuario
+3. **Claude's Discretion** — Documentar decisiones tomadas por Claude
+</context_fidelity>
+```
+
+### Estado Actual en fork_agent
+- El workflow state guarda tareas y estado
+- NO hay forma de marcar decisiones "locked" vs "deferred"
+- Las decisiones del usuario se pierden entre fases
+
+### Idea para fork_agent
+Añadir un campo `decisions` al workflow state que diferencie:
+- `locked`: El usuario decidió X, NO se puede cambiar
+- `deferred`: El usuario dijo "después", NO incluir en plan actual
+- `discretion`: Queda a criterio de Claude
+
+```python
+@dataclass
+class UserDecision:
+    key: str
+    value: str
+    status: Literal["locked", "deferred", "discretion"]
+    rationale: str | None = None
+```
+
+---
+
+## 2. Goal-Backward Planning (Planificación Inversa)
+
+### El Concepto
+En GSD, el planner no parte de "qué hacer" sino de "qué resultado quiero":
+- Derivar "must-haves" desde el objetivo
+- Identificar qué es necesario para lograr el resultado
+- No es top-down, es goal-driven
+
+### Estado Actual en fork_agent
+- El workflow outline genera tareas desde cero
+- No hay backwards chaining desde el objetivo
+
+### Idea para fork_agent
+Añadir fase de **goal analysis** al comando outline:
+1. Definir resultado final esperado
+2. Derivar requisitos mínimos (must-haves)
+3. Identificar dependencias entre tareas
+4. Generar plan desde el objetivo hacia atrás
+
+Esto填补 la gap: `GAP-WF-002 State Validation` porque hace explícito el goal.
+
+---
+
+## 3. Verificación Sistemática (Agente gsd-verifier)
+
+### El Concepto
+GSD tiene un agente dedicado a verificar que el trabajo cumple specs:
+- No es auto-verificación (el executor no se verifica a sí mismo)
+- Usa evidencia objetiva
+- Reporta gaps de forma estructurada
+
+### Estado Actual en fork_agent
+- El comando `verify` corre tests pero no valida contra specs explícitos
+- No hay "evidence collection" estructurada
+
+### Idea para fork_agent
+Separar la verificación en dos pasos:
+1. **Evidence collection** — Recopilar outputs, test results, logs
+2. **Spec validation** — Comparar evidencia contra requirements
+
+Esto填补: `GAP-WF-002 State Validation` + `GAP-WF-003 Phase Skip Prevention`
+
+---
+
+## 4. Meta-Prompting como Configuración
+
+### El Concepto
+GSD define agentes como prompts estructurados con frontmatter:
+```yaml
+---
+name: gsd-planner
+description: Creates executable phase plans...
+tools: Read, Write, Bash, Glob, Grep
+color: green
+---
+<role>...</role>
+```
+
+### Estado Actual en fork_agent
+- Los agentes están hardcodeados en Python (AgentManager)
+- Para añadir un agente, hay que editar código
+
+### Idea para fork_agent
+Crear un sistema de **agent definitions** como archivos de configuración:
+- Agents definidos en JSON/YAML
+- tools permitidas configurables
+- Código Python solo ejecuta, no define comportamiento
+
+Esto填补: `GAP-PT-001 Multi-Agent Platform Support`
+
+---
+
+## 5. Phase Research (Investigación de Contexto)
+
+### El Concepto
+GSD tiene fases de "research" antes de planificar:
+- Investigar el codebase existente
+- Investigar tecnologías/dependencies
+- Documentar contexto antes de actuar
+
+### Estado Actual en fork_agent
+- El workflow tiene: outline → execute → verify → ship
+- NO hay fase de investigación obligatoria
+
+### Idea para fork_agent
+Añadir fase **research** antes de outline:
+- Auto-detectar stack tecnológico
+- Analizar estructura del proyecto
+- Identificar skills y conventions disponibles
+- Generar contexto para el planner
+
+Esto填补: `GAP-WF-001 State Schema Versioning` (context auto-discovery)
+
+---
+
+## 6. Context Rot Prevention
+
+### El Concepto
+GSD resuelve el "context rot" — degradación de calidad cuando el contexto se llena:
+- Prompts estructurados con XML
+- Información condensada
+- Contexto relevante فقط
+
+### Estado Actual en fork_agent
+- Memoria es un SQLite con search FTS5
+- NO hay sistema de resumen/compresión de contexto
+- El contexto crece sin límite
+
+### Idea para fork_agent
+Implementar **context summarization**:
+- Detect when context window is filling up
+- Generate condensed summary of previous work
+- Keep only actionable context for current phase
+
+Esto es un **nuevo feature** no cubierto por gaps actuales.
+
+---
+
+## 7. Pattern: Commands as Prompts
+
+### El Concepto
+En GSD, los comandos (`/gsd:plan-phase`) son prompts que invocan agentes:
+- No es CLI tradicional
+- Es un prompt estructurado que pasa contexto al agente
+
+### Estado Actual en fork_agent
+- Comandos CLI en Typer
+- Lógica de negocio en Use Cases
+-分离
+
+### Idea para fork_agent
+Híbrido: mantener CLI pero permitir que commands pasen contexto enriquecido:
+- El command pre-procesa el contexto
+- Pasa información estructurada al agente
+- No cambiar la arquitectura, cambiar el contenido
+
+---
+
+## Resumen de Mejoras Identificadas
+
+| # | Idea | Gaps que填补 | Complejidad |
+|---|------|-------------|-------------|
+| 1 | User decisions tracking | GAP-WF-002 | Media |
+| 2 | Goal-backward planning | GAP-WF-001, GAP-WF-002 | Alta |
+| 3 | Separate verification agent | GAP-WF-002, GAP-WF-003 | Media |
+| 4 | Agent definitions as config | GAP-PT-001 | Alta |
+| 5 | Phase research | GAP-WF-001 | Media |
+| 6 | Context summarization | (nuevo) | Alta |
+
+---
+
+## Recomendaciones Prioritarias
+
+### Inmediato (1 sprint)
+1. **User decisions tracking** — Bajo impacto, alta utilidad
+2. **Goal analysis en outline** — Mejora calidad de planes
+
+### Corto plazo (2 sprints)
+3. **Evidence collection** — Mejora verification
+4. **Phase research** — Mejora contexto
+
+### Largo plazo
+5. Agent definitions as config
+6. Context summarization
+
+---
+
+*Documento generado: 2026-02-25*
+*Inspiración: GSD (get-shit-done) + fork_agent codebase audit*

--- a/docs/informes/database-analysis-memory-db.md
+++ b/docs/informes/database-analysis-memory-db.md
@@ -1,0 +1,331 @@
+# Technical Database Analysis Report: memory.db
+
+**Analysis Date:** 2026-02-25  
+**Database:** `data/memory.db`  
+**Database Size:** 184.00 KB (188,416 bytes)  
+**Total Tables:** 6  
+**Total Indexes:** 23  
+**Total Triggers:** 3
+
+---
+
+## 1. Executive Summary
+
+The `memory.db` database is a well-architected SQLite database for the fork_agent memory management system. It demonstrates solid design patterns with proper indexing, full-text search capabilities, and a clean schema. However, there are several areas for optimization and some unused infrastructure.
+
+### Overall Assessment: **GOOD** (7.5/10)
+
+| Aspect | Score | Notes |
+|--------|-------|-------|
+| Schema Design | 9/10 | Clean, normalized, proper use of foreign keys |
+| Indexing | 8/10 | Comprehensive indexes, minor gaps |
+| Data Integrity | 10/10 | FTS sync, no duplicates, integrity check passes |
+| Performance | 7/10 | Good for current load, needs optimization at scale |
+| Maintainability | 8/10 | Migration system in place, clear structure |
+| Telemetry Integration | 3/10 | Tables exist but unused |
+
+---
+
+## 2. Schema Analysis
+
+### 2.1 Database Objects
+
+| Type | Count |
+|------|-------|
+| Tables | 6 |
+| Indexes | 23 |
+| Triggers | 3 |
+| Virtual Tables (FTS) | 5 |
+
+### 2.2 Table Definitions
+
+#### `observations` (Primary Table)
+```
+Columns:
+- id: TEXT PRIMARY KEY (UUID)
+- timestamp: INTEGER NOT NULL (Unix ms)
+- content: TEXT NOT NULL
+-JSON)
+```
+
+**Analysis:** metadata: TEXT ( Clean design with UUID primary key. The `timestamp` is integer-based (Unix milliseconds) which is excellent for sorting and time-range queries.
+
+#### `scheduled_tasks`
+```
+Columns:
+- id: TEXT PRIMARY KEY
+- scheduled_at: INTEGER NOT NULL
+- action: TEXT NOT NULL
+- context: TEXT
+- status: TEXT NOT NULL DEFAULT 'PENDING'
+- created_at: INTEGER NOT NULL
+```
+
+**Status:** Empty (0 rows) - Feature not yet implemented or used.
+
+#### `telemetry_events`
+```
+Columns:
+- id: TEXT PRIMARY KEY
+- event_type: TEXT NOT NULL
+- event_category: TEXT NOT NULL
+- timestamp: INTEGER NOT NULL
+- received_at: INTEGER NOT NULL
+- session_id: TEXT
+- correlation_id: TEXT
+- parent_event_id: TEXT
+- attributes: TEXT NOT NULL (JSON)
+- metrics: TEXT (JSON)
+- processed: INTEGER DEFAULT 0
+- processed_at: INTEGER
+- expires_at: INTEGER NOT NULL
+```
+
+**Status:** Empty (0 rows) - Telemetry system not integrated.
+
+#### `telemetry_metrics`
+```
+Columns:
+- id: TEXT PRIMARY KEY
+- metric_name: TEXT NOT NULL
+- metric_type: TEXT NOT NULL
+- labels: TEXT (JSON)
+- labels_hash: TEXT
+- bucket_start: INTEGER NOT NULL
+- bucket_duration: INTEGER NOT NULL
+- value_count: INTEGER DEFAULT 0
+- value_sum: REAL DEFAULT 0
+- value_min: REAL
+- value_max: REAL
+- value_last: REAL
+- updated_at: INTEGER NOT NULL
+```
+
+**Status:** Empty (0 rows) - Metrics aggregation not implemented.
+
+#### `telemetry_sessions`
+```
+Columns:
+- session_id: TEXT PRIMARY KEY
+- workspace_id: TEXT
+- started_at: INTEGER NOT NULL
+- ended_at: INTEGER
+- duration_ms: INTEGER
+- hooks_fired/hooks_succeeded/hooks_failed: INTEGER
+- agents_spawned/agents_completed/agents_failed: INTEGER
+- memory_saves/memory_searches/memory_deletes: INTEGER
+- workflow_started/workflow_completed/workflow_aborted: INTEGER
+- status: TEXT DEFAULT 'active'
+- platform/python_version/fork_agent_version: TEXT
+```
+
+**Status:** Empty (0 rows) - Session tracking not integrated.
+
+#### `_migrations`
+```
+Columns:
+- version: INTEGER PRIMARY KEY
+- name: TEXT NOT NULL
+- applied_at: TEXT NOT NULL
+```
+
+**Status:** 5 migrations applied successfully.
+
+---
+
+## 3. Index Analysis
+
+### 3.1 Existing Indexes
+
+| Table | Index Name | Columns | Purpose |
+|-------|------------|---------|---------|
+| observations | idx_observations_timestamp | timestamp | Time-range queries |
+| scheduled_tasks | idx_scheduled_tasks_scheduled_at | scheduled_at | Task scheduling |
+| scheduled_tasks | idx_scheduled_tasks_status | status | Filter by status |
+| scheduled_tasks | idx_scheduled_tasks_status_scheduled_at | (status, scheduled_at) | Composite |
+| telemetry_events | idx_telemetry_events_type | event_type | Event filtering |
+| telemetry_events | idx_telemetry_events_category | event_category | Category filtering |
+| telemetry_events | idx_telemetry_events_session | session_id | Session queries |
+| telemetry_events | idx_telemetry_events_timestamp | timestamp | Time filtering |
+| telemetry_events | idx_telemetry_events_expires | expires_at | TTL/cleanup |
+| telemetry_events | idx_telemetry_events_correlation | correlation_id | Event chaining |
+| telemetry_events | idx_telemetry_events_type_timestamp | (event_type, timestamp) | Composite |
+| telemetry_events | idx_telemetry_events_session_type | (session_id, event_type) | Composite |
+| telemetry_events | idx_telemetry_events_category_timestamp | (event_category, timestamp) | Composite |
+| telemetry_metrics | idx_telemetry_metrics_name | metric_name | Metric lookup |
+| telemetry_metrics | idx_telemetry_metrics_bucket | bucket_start | Time buckets |
+| telemetry_metrics | idx_telemetry_metrics_name_bucket | (metric_name, bucket_start) | Composite |
+| telemetry_metrics | idx_telemetry_metrics_type | metric_type | Type filtering |
+| telemetry_metrics | idx_telemetry_metrics_unique | (metric_name, labels_hash, bucket_start) | UNIQUE |
+| telemetry_sessions | idx_telemetry_sessions_started | started_at | Time filtering |
+| telemetry_sessions | idx_telemetry_sessions_status | status | Status filtering |
+| telemetry_sessions | idx_telemetry_sessions_workspace | workspace_id | Workspace queries |
+| telemetry_sessions | idx_telemetry_sessions_ended | ended_at | Query ended sessions |
+
+### 3.2 Missing Indexes
+
+1. **observations.id** - Primary key lookups (UUID) use table scan (though PK index exists implicitly)
+2. **observations.metadata** - No index for metadata field queries
+3. **telemetry_events.parent_event_id** - Missing for event hierarchy queries
+
+---
+
+## 4. Full-Text Search (FTS) Analysis
+
+### 4.1 FTS Configuration
+
+- **Type:** FTS5 (latest SQLite FTS)
+- **Indexed Column:** content
+- **Sync Status:** ✅ SYNCED (52 observations = 52 FTS entries)
+
+### 4.2 Triggers
+
+| Trigger | Event | Action |
+|---------|-------|--------|
+| observations_after_insert | INSERT | Add to FTS |
+| observations_after_delete | DELETE | Remove from FTS |
+| observations_after_update | UPDATE | Re-index in FTS |
+
+### 4.3 FTS Performance
+
+| Query Type | Time (100 iterations) | Avg per Query |
+|------------|----------------------|---------------|
+| LIKE search | 30.87ms | 0.31ms |
+| FTS search | 27.77ms | 0.28ms |
+
+**Finding:** FTS is slightly faster than LIKE (as expected). However, for small datasets, the difference is negligible.
+
+---
+
+## 5. Data Quality Analysis
+
+### 5.1 Observations Table
+
+| Metric | Value |
+|--------|-------|
+| Total Rows | 52 |
+| NULL/Empty Content | 0 |
+| Duplicate IDs | 0 |
+| FTS Desync | 0 |
+
+### 5.2 Content Patterns
+
+| Pattern | Count (last 20) |
+|---------|----------------|
+| workflow_events | 19 |
+| session_start | 1 |
+
+### 5.3 Metadata Usage
+
+- **Observations with metadata:** 50/52 (96%)
+- **Metadata keys used:**
+
+| Key | Frequency |
+|-----|-----------|
+| phase | 50 |
+| plan_id | 50 |
+| test_results | 18 |
+| target_branch | 14 |
+| task_description | 9 |
+| task_count | 9 |
+| sessions_spawned | 9 |
+
+---
+
+## 6. Query Performance Analysis
+
+### 6.1 Benchmark Results (100 iterations each)
+
+| Query | Total Time | Avg per Query |
+|-------|------------|--------------|
+| Get 10 recent observations | 16.32ms | 0.16ms |
+| LIKE search (%workflow%) | 30.87ms | 0.31ms |
+| Timestamp filter | 19.39ms | 0.19ms |
+| FTS search | 27.77ms | 0.28ms |
+| UUID lookup | 1.93ms | 0.02ms |
+
+### 6.2 Performance Findings
+
+1. **UUID lookup is fastest** (0.02ms) - Primary key indexes work well
+2. **FTS vs LIKE:** FTS is ~10% faster for text search
+3. **All queries are fast** - Sub-millisecond average for current dataset
+
+---
+
+## 7. Issues Identified
+
+### 7.1 Critical Issues
+
+| # | Issue | Impact | Recommendation |
+|---|-------|--------|----------------|
+| 1 | **Telemetry tables empty** | High - Features not integrated | Integrate telemetry event capture or remove tables |
+| 2 | **Scheduled tasks unused** | Medium - Feature not implemented | Implement or remove |
+
+### 7.2 Optimization Opportunities
+
+| # | Issue | Impact | Recommendation |
+|---|-------|--------|----------------|
+| 3 | **Missing index on parent_event_id** | Low - Table is empty | Add if telemetry is integrated |
+| 4 | **metadata column is TEXT** | Low - No type checking | Consider JSON1 extension for validation |
+| 5 | **No TTL policy** | Medium - Database will grow | Implement automatic cleanup for old observations |
+
+### 7.3 Design Considerations
+
+| # | Issue | Impact | Recommendation |
+|---|-------|--------|----------------|
+| 6 | **Composite indexes may be redundant** | Low | Review idx_telemetry_events_type_timestamp, etc. |
+| 7 | **No pagination support** | Medium | Add OFFSET/LIMIT patterns to CLI |
+
+---
+
+## 8. Recommendations
+
+### 8.1 Immediate Actions
+
+1. **Integrate Telemetry System** - The infrastructure is in place but not being used. Either:
+   - Integrate the telemetry service to capture events
+   - Or remove the unused tables to reduce database size
+
+2. **Add TTL for Observations** - Implement automatic cleanup:
+   ```sql
+   DELETE FROM observations WHERE timestamp < strftime('%s','now')*1000 - 90*86400000;
+   ```
+
+3. **Add Index on observations.id** - For explicit UUID lookups (though PK index exists)
+
+### 8.2 Long-term Improvements
+
+1. **Partition by Time** - For large datasets, consider table partitioning
+2. **Archive Old Data** - Move observations > 90 days to cold storage
+3. **Add Query Logging** - Identify slow queries in production
+4. **Implement Scheduled Tasks** - If the feature is planned, implement it
+
+### 8.3 Code Quality
+
+1. **Add Database Version Checks** - Ensure migrations are run on startup
+2. **Add Health Checks** - Verify FTS sync status
+3. **Add Monitoring** - Track query performance in production
+
+---
+
+## 9. Migration History
+
+| Version | Name | Applied At |
+|---------|------|------------|
+| v1 | create_observations_table | 2026-02-25 17:09:53 |
+| v2 | create_scheduled_tasks_table | 2026-02-25 17:09:53 |
+| v3 | create_telemetry_events_table | 2026-02-25 17:09:53 |
+| v4 | create_telemetry_metrics_table | 2026-02-25 17:09:54 |
+| v5 | create_telemetry_sessions_table | 2026-02-25 17:09:54 |
+
+---
+
+## 10. Conclusion
+
+The database schema is well-designed and follows best practices for SQLite. The main issues are:
+
+1. **Unused telemetry infrastructure** - Either integrate or remove
+2. **No data lifecycle management** - Needs TTL/archival policy
+3. **Minor indexing gaps** - Can be optimized as needed
+
+For the current dataset size (52 observations, 184KB), performance is excellent. As the dataset grows, consider the recommendations above to maintain performance.

--- a/docs/plan/ACTION-PLAN-GSD-FORK-AGENT.md
+++ b/docs/plan/ACTION-PLAN-GSD-FORK-AGENT.md
@@ -1,0 +1,416 @@
+# Plan de Acción: Análisis Cruzado GSD vs fork_agent
+
+> **Fuente:** [`docs/informes/CROSS-ANALYSIS-GSD-FORK-AGENT.md`](docs/informes/CROSS-ANALYSIS-GSD-FORK-AGENT.md)  
+> **Fecha de generación:** 2026-02-25  
+> **Tipo:** Roadmap técnico priorizado
+
+---
+
+## Resumen Ejecutivo
+
+Este plan consolida las oportunidades de mejora identificadas en el análisis cruzado entre GSD (get-shit-done) y fork_agent. El objetivo es fortalecer la arquitectura DDD de fork_agent mediante la incorporación de patrones probados de GSD, particularmente en gestión de estado, verificación sistemática y contexto.
+
+**Prioridades clave:**
+- **P0 (Completado):** State Schema Versioning ✅, Hook Criticality Levels ✅, Migration System ✅
+- **P1 (Inmediata):** User Decisions Tracking, Phase Skip Prevention
+- **P2 (1-2 Sprints):** Goal Analysis, Evidence Collection, Phase Research
+- **P3 (Largo Plazo):** Agent Definitions as Config, Context Summarization
+
+---
+
+## 1. Brechas Críticas (P0) - COMPLETADO
+
+> ⚠️ **NOTA:** Estas brechas fueron identificadas en análisis anteriores pero YA ESTÁN IMPLEMENTADAS en el código actual.
+
+### 1.1 GAP-WF-001: State Schema Versioning ✅ COMPLETADO
+
+| Atributo | Detalle |
+|----------|---------|
+| **Prioridad** | P0 - COMPLETADO |
+| **Complejidad** | N/A |
+| **Dependencias** | Ninguna |
+| **Módulo afectado** | `src/application/services/workflow/state.py` |
+
+**Estado actual:** ✅ IMPLEMENTADO
+- `CURRENT_SCHEMA_VERSION = 1` definido en línea 12
+- Campo `schema_version` en PlanState, ExecuteState, VerifyState
+- Migración automática v0 → v1 en `from_json()`
+- Excepciones `UnsupportedSchemaError` para versiones futuras
+
+**Acción requerida:** Ninguna - verificar periodically con tests existentes
+
+---
+
+### 1.2 GAP-WF-003: Phase Skip Prevention
+
+| Atributo | Detalle |
+|----------|---------|
+| **Prioridad** | P0 - Crítica |
+| **Complejidad** | Baja |
+| **Dependencias** | Ninguna (schema ya implementado) |
+| **Módulo afectado** | `src/application/services/workflow/`, CLI commands |
+
+**Descripción:** No hay validación a nivel de API/Use Cases para prevenir saltos de fase.
+
+**Acción requerida:**
+- [ ] Implementar validación en Use Cases antes de transiciones de fase
+- [ ] Añadir checks en `src/application/use_cases/`
+- [ ] Crear excepción `PhaseSkipError` en `src/application/exceptions.py`
+
+---
+
+### 1.3 GAP-DB-001: Migration System ✅ COMPLETADO
+
+| Atributo | Detalle |
+|----------|---------|
+| **Prioridad** | P0 |
+| **Complejidad** | Alta |
+| **Dependencias** | Schema existente (GAP-WF-001 ya implementado) |
+| **Módulo afectado** | `src/infrastructure/persistence/` |
+
+**Acción requerida:**
+- [ ] Diseñar sistema de migraciones de schema
+- [ ] Implementar CLI para ejecución de migraciones
+- [ ] Crear tabla de metadata de migraciones
+
+---
+
+### 1.4 GAP-DB-002: Idempotency Mechanism
+
+| Atributo | Detalle |
+|----------|---------|
+| **Prioridad** | P0 |
+| **Complejidad** | Media |
+| **Dependencias** | Ninguna |
+
+**Acción requerida:**
+- [ ] Implementar IDs idempotentes para operaciones de workflow
+- [ ] Añadir checks de operación duplicada antes de ejecutar
+- [ ] Documentar en `docs/`
+
+---
+
+### 1.5 GAP-HK-001: Hook Criticality Levels ✅ COMPLETADO
+
+| Atributo | Detalle |
+|----------|---------|
+| **Prioridad** | P0 - COMPLETADO |
+| **Complejidad** | N/A |
+| **Dependencias** | Ninguna |
+| **Módulo afectado** | `src/application/services/orchestration/actions.py` |
+
+**Estado actual:** ✅ IMPLEMENTADO
+- Campo `critical: bool = True` en `HookSpec` (actions.py línea 30)
+- Método `continue_on_failure()` implementado
+- Uso en `.hooks/hooks.json` con valores `true`/`false`
+
+**Acción requerida:** Ninguna
+
+---
+
+## 2. Oportunidades de Alta Prioridad (1 Sprint)
+
+### 2.1 Oportunidad 1: User Decisions Tracking
+
+| Atributo | Detalle |
+|----------|---------|
+| **Prioridad** | Alta |
+| **Complejidad** | Media |
+| **Impacto** | Alto |
+| **Brechas relacionadas** | GAP-WF-002, GAP-WF-003 |
+| **Módulo afectado** | `src/application/services/workflow/` |
+
+**Descripción:** Implementar sistema de seguimiento de decisiones del usuario en el workflow state para preservar contexto entre interacciones.
+
+**Acciones requeridas:**
+
+1. **Crear clase UserDecision** (`src/domain/entities/` o `src/application/services/workflow/`)
+   ```python
+   @dataclass
+   class UserDecision:
+       key: str
+       value: str
+       status: Literal["locked", "deferred", "discretion"]
+       rationale: str | None = None
+   ```
+
+2. **Extender WorkflowState**
+   - Añadir campo `decisions: dict[str, UserDecision]`
+   - Implementar métodos para adicionar/consultar decisiones
+
+3. **Integrar con CLI**
+   - Modificar comandos para consultar decisiones antes de ejecutar
+   - Añadir comando para listar decisiones del workflow
+
+4. **Tests**
+   - [ ] Crear tests unitarios en `tests/unit/application/services/workflow/`
+   - [ ] Verificar serialización/deserialización
+
+**Métricas de éxito:**
+- Decisiones persistentes entre fases del workflow
+- CLI muestra estado de decisiones
+- 90% cobertura de tests
+
+---
+
+### 2.2 Oportunidad 2: Goal Analysis en Outline
+
+| Atributo | Detalle |
+|----------|---------|
+| **Prioridad** | Alta |
+| **Complejidad** | Alta |
+| **Impacto** | Alto |
+| **Brechas relacionadas** | Schema existente (State Schema Versioning) |
+| **Módulo afectado** | CLI commands (`src/interfaces/cli/commands/workflow.py`) |
+
+**Descripción:** Incorporar análisis de objetivo en la fase de outline, siguiendo el patrón goal-backward planning de GSD.
+
+**Acciones requeridas:**
+
+1. **Extender comando outline**
+   - Añadir parámetros para aceptar objetivo (--goal, --must-haves)
+   - Procesar y almacenar en PlanState
+
+2. **Extender PlanState**
+   - Añadir campos: `goal`, `must_haves`, `derived_requirements`
+   - Requerirá migración de schema (depende de GAP-WF-001)
+
+3. **Implementar derivación de requisitos**
+   - Análisis del objetivo para derivar requisitos mínimos
+   - Identificación de dependencias entre tareas
+   - Generación de plan backward desde objetivo
+
+4. **Tests**
+   - [ ] Tests de derivación de requisitos
+   - [ ] Tests de integración con workflow
+
+**Métricas de éxito:**
+- Outline genera plan que cumple requisitos mínimos
+- Trazabilidad entre objetivo y tareas generadas
+
+---
+
+## 3. Oportunidades de Prioridad Media (2 Sprints)
+
+### 3.1 Oportunidad 3: Evidence Collection para Verificación
+
+| Atributo | Detalle |
+|----------|---------|
+| **Prioridad** | Media |
+| **Complejidad** | Media |
+| **Impacto** | Directo en confiabilidad |
+| **Brechas relacionadas** | GAP-WF-002, GAP-WF-003 |
+| **Módulo afectado** | `src/application/services/workflow/`, `src/application/services/agent/` |
+
+**Descripción:** Separar verificación en dos pasos: recolección de evidencia y validación contra specifications.
+
+**Acciones requeridas:**
+
+1. **Crear módulo EvidenceCollector**
+   - Recopilar outputs de ejecución
+   - Recopilar resultados de tests
+   - Recopilar logs relevantes
+
+2. **Crear SpecValidator**
+   - Comparar evidencia contra requisitos explícitos
+   - Reportar brechas de forma estructurada
+
+3. **Integrar con workflow**
+   - Añadir fase de evidence collection antes de verify
+   - Almacenar evidencia en estado
+
+**Métricas de éxito:**
+- Evidencia recopilada automáticamente en cada ejecución
+- Reporte estructurado de cumplimiento de specs
+
+---
+
+### 3.2 Oportunidad 4: Phase Research Integration
+
+| Atributo | Detalle |
+|----------|---------|
+| **Prioridad** | Media |
+| **Complejidad** | Media |
+| **Impacto** | Calidad de planificación |
+| **Brechas relacionadas** | GAP-WF-001 |
+| **Módulo afectado** | `src/application/services/workspace/`, workflow |
+
+**Descripción:** Añadir fase de investigación obligatoria antes de planificar/ejecutar.
+
+**Acciones requeridas:**
+
+1. **Integrar con workspace detection existente**
+   - Utilizar `workspace_detector.py` como base
+   - Añadir detección de stack tecnológico
+
+2. **Extender workflow state**
+   - Añadir campos para contexto investigado
+   - Requerirá versionado de schema
+
+3. **Crear agentes de investigación**
+   - gsd-phase-researcher (análisis de fase)
+   - gsd-project-researcher (contexto de proyecto)
+   - gsd-codebase-mapper (estructura del codebase)
+
+**Métricas de éxito:**
+- Contexto auto-descubierto disponible en planificación
+- Reducción de errores por falta de contexto
+
+---
+
+## 4. Oportunidades de Baja Prioridad (Largo Plazo)
+
+### 4.1 Oportunidad 5: Agent Definitions as Config
+
+| Atributo | Detalle |
+|----------|---------|
+| **Prioridad** | Baja |
+| **Complejidad** | Alta |
+| **Impacto** | Mantenibilidad y extensibilidad |
+| **Brechas relacionadas** | GAP-PT-001 |
+| **Módulo afectado** | `src/application/services/agent/` |
+
+**Descripción:** Migrar agentes de código Python a configuración JSON/YAML.
+
+**Acciones requeridas:**
+
+1. **Diseñar schema de AgentDefinition**
+   - Definir estructura YAML/JSON para agentes
+   - Incluir prompts, tools permitidas, comportamientos
+
+2. **Crear AgentDefinitionLoader**
+   - Cargar definiciones de archivos de configuración
+   - Traducir a comportamiento ejecutable
+
+3. **Refactorizar AgentManager**
+   - Mantener como capa de ejecución
+   - Cargar definiciones dinámicamente
+
+4. **Estrategia de transición**
+   - Mantener agentes actuales durante migración
+   - Migrar incrementalmente
+
+**Métricas de éxito:**
+- Nuevos agentes añadibles sin modificar código
+- Separation completa de definición y ejecución
+
+---
+
+### 4.2 Oportunidad 6: Context Summarization
+
+| Atributo | Detalle |
+|----------|---------|
+| **Prioridad** | Baja |
+| **Complejidad** | Alta |
+| **Impacto** | Sesiones largas |
+| **Brechas relacionadas** | Nueva (no mapeada en DECISION-GAPS) |
+
+**Descripción:** Sistema de resumen/compresión de contexto cuando la ventana se llena.
+
+**Acciones requeridas:**
+
+1. **Implementar detección de ventana llena**
+   - Monitorizar tamaño de contexto
+   - Trigger antes de overflow
+
+2. **Crear sistema de generación de resúmenes**
+   - Técnicas de summary extraction
+   - Retención de contexto accionable
+
+3. **Integrar con sistema de memoria**
+   - Usar SQLite existente con FTS5
+   - Añadir tabla de resúmenes
+
+**Métricas de éxito:**
+- Resúmenes generados automáticamente
+- Mantenimiento de calidad de respuestas con contexto reducido
+
+---
+
+## 5. Recomendaciones Transversales
+
+### 5.1 Arquitectura
+
+| # | Recomendación | Dependencia | Complejidad |
+|---|---------------|-------------|-------------|
+| ARQ-1 | Adoptar patrón de agentes especializados | Oportunidad 3 | Media |
+| ARQ-2 | Implementar versionado de schema | ✅ Completado | Media |
+| ARQ-3 | Separar definición de ejecución de agentes | Oportunidad 5 | Alta |
+
+### 5.2 Proceso
+
+| # | Recomendación | Dependencia | Complejidad |
+|---|---------------|-------------|-------------|
+| PROC-1 | Implementar pruebas de workflow state | Todas | Media |
+| PROC-2 | Establecer métricas de contexto | Oportunidad 6 | Baja |
+
+### 5.3 Técnicas
+
+| # | Recomendación | Dependencia | Complejidad |
+|---|---------------|-------------|-------------|
+| TECH-1 | Extender hooks.json para criticalidad | GAP-HK-001 | Baja |
+| TECH-2 | Unificar configuraciones de CircuitBreaker | Ninguna | ✅ COMPLETADO |
+
+---
+
+## 6. Matriz de Dependencias
+
+```
+GAP-WF-001 (Schema Versioning) - ✅ COMPLETADO
+├── Oportunidad 2 (Goal Analysis)
+├── Oportunidad 4 (Phase Research)
+└── Oportunidad 5 (Agent Config)
+
+Oportunidad 1 (User Decisions)
+├── Requires: Estado actual con schema versioning
+└── Enables: Oportunidad 3 (Evidence Collection)
+
+Oportunidad 3 (Evidence Collection)
+└── Enables: Oportunidad 5 (Agent Config - verification agent)
+```
+
+---
+
+## 7. Roadmap Visual
+
+| Fase | Sprint 1 | Sprint 2 | Sprint 3 | Sprint 4+ |
+|------|----------|----------|----------|-----------|
+| **Infraestructura** | ✅ GAP-WF-001 | ✅ GAP-DB-001 | - | - |
+| **Alta Prioridad** | Oportunidad 1 | Oportunidad 2 | - | - |
+| **Media Prioridad** | - | - | Opp 3 | Opp 4 |
+| **Largo Plazo** | - | - | - | Opp 5, 6 |
+
+---
+
+## 8. Métricas de Éxito del Plan
+
+### Métricas Técnicas
+- **Cobertura de tests:** ≥ 95% en módulos modificados
+- **Schema versioning:** 100% estados versionados
+- **Migraciones:**Compatibilidad N-1 verificada
+
+### Métricas Funcionales
+- **User Decisions:** Persistencia verificada entre fases
+- **Goal Analysis:** Trazabilidad objetivo → tareas
+- **Evidence Collection:** Recopilación automática
+- **Phase Research:** Contexto disponible en planificación
+
+### Métricas de Contexto (Recomendación PROC-2)
+- Tokens por sesión
+- Crecimiento de contexto por fase
+- Correlación con calidad de outputs
+
+---
+
+## 9. Referencias
+
+- [`docs/informes/ARCHITECTURE.md`](docs/informes/ARCHITECTURE.md) - Arquitectura de referencia
+- [`docs/informes/DECISION-GAPS.md`](docs/informes/DECISION-GAPS.md) - Catálogo de brechas
+- [`docs/informes/EXPLORATION-DECISION-INPUTS.md`](docs/informes/EXPLORATION-DECISION-INPUTS.md) - Evidencia de pruebas
+- [`docs/informes/GSD-IDEAS-FORK-AGENT.md`](docs/informes/GSD-IDEAS-FORK-AGENT.md) - Ideas de transferencia
+- [GSD Repository](https://github.com/gsd-build/get-shit-done) - Proyecto de referencia
+
+---
+
+*Documento generado automáticamente desde CROSS-ANALYSIS-GSD-FORK-AGENT.md*
+*Última actualización: 2026-02-25*

--- a/docs/plan/database-optimization-plan.md
+++ b/docs/plan/database-optimization-plan.md
@@ -1,0 +1,69 @@
+# Database Optimization Plan - IMPLEMENTED
+
+**Goal:** Optimize `memory.db` based on technical analysis
+
+---
+
+## Tasks Completed
+
+### ✅ 1. TTL/Cleanup Policy
+- Created: `src/application/services/cleanup_service.py`
+- CLI: `memory cleanup --days 90 --dry-run`
+- Supports `--vacuum` and `--optimize-ft` flags
+
+### ✅ 2. Health Checks
+- Created: `src/infrastructure/persistence/health_check.py`
+- CLI: `memory health`
+- Checks: integrity, FTS sync, stats
+- Supports `--fix` flag to repair FTS
+
+### ⏸️ 3. Telemetry Decision
+- Deferred - requires significant implementation work
+- Can be revisited later
+
+### ✅ 4. Pagination
+- Added `--offset` to list command
+- Fixed limit to use SQL LIMIT instead of Python slice
+- Now: `memory list --limit 20 --offset 0`
+
+### ✅ 5. Query Logging
+- Created: `src/infrastructure/persistence/query_logger.py`
+- CLI: `memory stats --slow-queries`
+- Created: `memory clear-slow-queries`
+
+---
+
+## New CLI Commands
+
+| Command | Description |
+|---------|-------------|
+| `memory cleanup --days 90` | Preview old observations to delete |
+| `memory cleanup --days 90 --no-dry-run` | Actually delete old observations |
+| `memory health` | Check database health |
+| `memory stats` | Show database statistics |
+| `memory list --limit 10 --offset 0` | List with pagination |
+
+---
+
+## Files Created/Modified
+
+### Created
+- `src/application/services/cleanup_service.py`
+- `src/infrastructure/persistence/health_check.py`
+- `src/infrastructure/persistence/query_logger.py`
+- `src/interfaces/cli/commands/cleanup.py`
+- `src/interfaces/cli/commands/health.py`
+- `src/interfaces/cli/commands/stats.py`
+
+### Modified
+- `src/infrastructure/persistence/container.py` - Added cleanup_service, health_check_service
+- `src/interfaces/cli/dependencies.py` - Added getters
+- `src/interfaces/cli/main.py` - Registered new commands
+- `src/application/services/memory_service.py` - Fixed pagination
+- `src/interfaces/cli/commands/list.py` - Added offset option
+
+---
+
+## Skipped
+
+- Index on observations.id (redundant - SQLite auto-indexes PK)

--- a/docs/plan/database-optimization-plan.md
+++ b/docs/plan/database-optimization-plan.md
@@ -1,6 +1,722 @@
-# Database Optimization Plan - IMPLEMENTED
+# Database Optimization Plan
 
 **Goal:** Optimize `memory.db` based on technical analysis
+
+**Last Updated:** 2026-02-25
+
+---
+
+## Executive Summary
+
+The fork_agent database is well-architected with several optimizations already implemented, including FTS5 full-text search, query logging, health checks, and cleanup services. This plan identifies remaining opportunities for performance improvement, focusing on:
+
+- **Missing indexes** for telemetry and metadata queries
+- **Performance PRAGMA settings** for SQLite optimization
+- **Batch operations** for bulk inserts and cleanup
+- **Metadata JSON indexing** for observation filtering
+
+The current implementation is stable and performant for typical workloads. The recommended optimizations are low-risk enhancements that will improve performance as the database grows and telemetry features are activated.
+
+---
+
+## Current Schema Summary
+
+### Tables Overview
+
+| Table | Rows | Status | Purpose |
+|-------|------|--------|---------|
+| `observations` | 52 | Active | Core memory storage |
+| `scheduled_tasks` | 0 | Ready | Task scheduling |
+| `telemetry_events` | 0 | Ready | Event tracking |
+| `telemetry_metrics` | 0 | Ready | Metrics storage |
+| `telemetry_sessions` | 0 | Ready | Session tracking |
+| `_migrations` | 5 | System | Schema versioning |
+
+### Schema Details
+
+#### observations table
+
+```sql
+CREATE TABLE observations (
+    id TEXT PRIMARY KEY,
+    content TEXT NOT NULL,
+    metadata TEXT,  -- JSON blob
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+-- FTS5 virtual table for full-text search
+CREATE VIRTUAL TABLE observations_fts USING fts5(
+    content,
+    content='observations',
+    content_rowid='rowid'
+);
+
+-- Sync triggers for FTS
+CREATE TRIGGER observations_ai AFTER INSERT ON observations BEGIN
+    INSERT INTO observations_fts(rowid, content) VALUES (new.rowid, new.content);
+END;
+
+CREATE TRIGGER observations_ad AFTER DELETE ON observations BEGIN
+    INSERT INTO observations_fts(observations_fts, rowid, content) 
+    VALUES ('delete', old.rowid, old.content);
+END;
+
+CREATE TRIGGER observations_au AFTER UPDATE ON observations BEGIN
+    INSERT INTO observations_fts(observations_fts, rowid, content) 
+    VALUES ('delete', old.rowid, old.content);
+    INSERT INTO observations_fts(rowid, content) VALUES (new.rowid, new.content);
+END;
+```
+
+### Existing Indexes
+
+| Table | Index Name | Columns | Type |
+|-------|------------|---------|------|
+| observations | `sqlite_autoindex_observations_1` | id | PRIMARY KEY |
+| observations | `idx_observations_created_at` | created_at | SINGLE |
+| observations | `idx_observations_updated_at` | updated_at | SINGLE |
+| observations | `idx_observations_created_updated` | created_at, updated_at | COMPOSITE |
+| observations | `idx_observations_updated_created` | updated_at, created_at | COMPOSITE |
+| scheduled_tasks | `sqlite_autoindex_scheduled_tasks_1` | id | PRIMARY KEY |
+| scheduled_tasks | `idx_scheduled_tasks_status` | status | SINGLE |
+| scheduled_tasks | `idx_scheduled_tasks_scheduled_at` | scheduled_at | SINGLE |
+| scheduled_tasks | `idx_scheduled_tasks_status_scheduled` | status, scheduled_at | COMPOSITE |
+| scheduled_tasks | `idx_scheduled_tasks_scheduled_status` | scheduled_at, status | COMPOSITE |
+| telemetry_events | `sqlite_autoindex_telemetry_events_1` | id | PRIMARY KEY |
+| telemetry_events | `idx_telemetry_events_session_id` | session_id | SINGLE |
+| telemetry_events | `idx_telemetry_events_event_type` | event_type | SINGLE |
+| telemetry_events | `idx_telemetry_events_timestamp` | timestamp | SINGLE |
+| telemetry_events | `idx_telemetry_events_session_type` | session_id, event_type | COMPOSITE |
+| telemetry_events | `idx_telemetry_events_session_time` | session_id, timestamp | COMPOSITE |
+| telemetry_events | `idx_telemetry_events_type_time` | event_type, timestamp | COMPOSITE |
+| telemetry_metrics | `sqlite_autoindex_telemetry_metrics_1` | id | PRIMARY KEY |
+| telemetry_metrics | `idx_telemetry_metrics_session_id` | session_id | SINGLE |
+| telemetry_metrics | `idx_telemetry_metrics_metric_name` | metric_name | SINGLE |
+| telemetry_metrics | `idx_telemetry_metrics_timestamp` | timestamp | SINGLE |
+| telemetry_sessions | `sqlite_autoindex_telemetry_sessions_1` | id | PRIMARY KEY |
+
+---
+
+## Detailed Indexing Strategy
+
+### Index 1: Metadata JSON Extraction
+
+For filtering observations by metadata fields (e.g., `{"type": "session"}`):
+
+```sql
+-- Add generated column for common metadata field
+ALTER TABLE observations ADD COLUMN metadata_type TEXT 
+    GENERATED ALWAYS AS (json_extract(metadata, '$.type')) STORED;
+
+-- Create index on generated column
+CREATE INDEX idx_observations_metadata_type ON observations(metadata_type);
+
+-- For JSON expression queries (SQLite 3.38+)
+CREATE INDEX idx_observations_metadata_json ON observations(json_extract(metadata, '$.type'));
+```
+
+**Use Case:** `memory list --filter type=session`
+
+### Index 2: Parent Event Hierarchy
+
+For telemetry event hierarchy queries:
+
+```sql
+-- Index for finding child events
+CREATE INDEX idx_telemetry_events_parent_id ON telemetry_events(parent_event_id);
+```
+
+**Use Case:** Fetching all child events of a span trace.
+
+### Index 3: Processed Events Filter
+
+For filtering unprocessed telemetry events:
+
+```sql
+-- Partial index for unprocessed events
+CREATE INDEX idx_telemetry_events_unprocessed ON telemetry_events(timestamp, event_type) 
+    WHERE processed_at IS NULL;
+```
+
+**Use Case:** Background worker processing pending events.
+
+### Indexes to Remove
+
+After telemetry activation, consider removing redundant single-column indexes covered by composites:
+
+```sql
+-- These are covered by composite indexes
+DROP INDEX IF EXISTS idx_telemetry_events_session_id;
+DROP INDEX IF EXISTS idx_telemetry_events_event_type;
+DROP INDEX IF EXISTS idx_telemetry_events_timestamp;
+```
+
+---
+
+## Query Optimization Recommendations
+
+### Current Query Patterns
+
+| Pattern | Query | Current Performance |
+|---------|-------|---------------------|
+| Get by ID | `SELECT * FROM observations WHERE id = ?` | 0.02ms (indexed) |
+| List all | `SELECT * FROM observations ORDER BY created_at DESC LIMIT ?` | 0.05ms (indexed) |
+| Search | `SELECT * FROM observations_fts WHERE observations_fts MATCH ?` | 0.28ms (FTS5) |
+| Time range | `SELECT * FROM observations WHERE created_at BETWEEN ? AND ?` | 0.08ms (indexed) |
+
+### Improvement 1: Batch Insert Operations
+
+Current approach inserts records one at a time. Batch operations reduce transaction overhead:
+
+```python
+# src/infrastructure/persistence/repositories/observation_repository.py
+
+from typing import Sequence
+
+class ObservationRepository:
+    def save_batch(self, observations: Sequence[Observation]) -> int:
+        """Save multiple observations in a single transaction."""
+        with self._conn:
+            cursor = self._conn.cursor()
+            cursor.executemany(
+                """
+                INSERT INTO observations (id, content, metadata, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                [
+                    (o.id, o.content, o.metadata, o.created_at, o.updated_at)
+                    for o in observations
+                ],
+            )
+            # Sync FTS
+            cursor.executescript("""
+                INSERT INTO observations_fts(observations_fts) VALUES ('rebuild');
+            """)
+            return cursor.rowcount
+```
+
+### Improvement 2: Count Optimization
+
+Use covering indexes for count queries:
+
+```sql
+-- Covering index for count queries
+CREATE INDEX idx_observations_count_covering ON observations(created_at) 
+    WHERE content IS NOT NULL;
+
+-- Optimized count query
+SELECT COUNT(*) FROM observations INDEXED BY idx_observations_count_covering;
+```
+
+### Improvement 3: FTS Search Optimization
+
+Add BM25 ranking for better search relevance:
+
+```python
+# Enhanced FTS search with ranking
+def search_with_ranking(self, query: str, limit: int = 10) -> list[Observation]:
+    """Search observations with BM25 ranking."""
+    cursor = self._conn.execute(
+        """
+        SELECT o.id, o.content, o.metadata, o.created_at, o.updated_at,
+               bm25(observations_fts) as rank
+        FROM observations o
+        JOIN observations_fts fts ON o.rowid = fts.rowid
+        WHERE observations_fts MATCH ?
+        ORDER BY rank
+        LIMIT ?
+        """,
+        (query, limit),
+    )
+    return [self._row_to_observation(row) for row in cursor.fetchall()]
+```
+
+---
+
+## Connection Pooling Strategy
+
+### Current Implementation
+
+The database connection uses thread-local storage with WAL mode:
+
+```python
+# src/infrastructure/persistence/database.py
+
+import threading
+import sqlite3
+from pathlib import Path
+
+_local = threading.local()
+
+def get_connection(db_path: Path) -> sqlite3.Connection:
+    """Get thread-local database connection."""
+    if not hasattr(_local, 'conn') or _local.conn is None:
+        _local.conn = sqlite3.connect(str(db_path))
+        _local.conn.execute("PRAGMA journal_mode=WAL")
+        _local.conn.execute("PRAGMA busy_timeout=5000")
+    return _local.conn
+```
+
+### Recommended Enhancements
+
+```python
+# src/infrastructure/persistence/database.py
+
+from pydantic import BaseModel
+from pathlib import Path
+import sqlite3
+from typing import Final
+
+class DatabaseConfig(BaseModel):
+    db_path: Path
+    # Performance PRAGMAs
+    cache_size: int = -64000  # 64MB cache
+    temp_store: str = "MEMORY"
+    mmap_size: int = 268435456  # 256MB mmap
+    synchronous: str = "NORMAL"
+    busy_timeout: int = 5000  # 5 seconds
+    
+    model_config = {"frozen": True}
+
+def get_connection(config: DatabaseConfig) -> sqlite3.Connection:
+    """Get thread-local database connection with performance optimizations."""
+    if not hasattr(_local, 'conn') or _local.conn is None:
+        _local.conn = sqlite3.connect(str(config.db_path))
+        
+        # Essential PRAGMAs
+        _local.conn.execute("PRAGMA journal_mode=WAL")
+        _local.conn.execute(f"PRAGMA busy_timeout={config.busy_timeout}")
+        
+        # Performance PRAGMAs
+        _local.conn.execute(f"PRAGMA cache_size={config.cache_size}")
+        _local.conn.execute(f"PRAGMA temp_store={config.temp_store}")
+        _local.conn.execute(f"PRAGMA mmap_size={config.mmap_size}")
+        _local.conn.execute(f"PRAGMA synchronous={config.synchronous}")
+        
+        # Enable foreign keys
+        _local.conn.execute("PRAGMA foreign_keys=ON")
+        
+    return _local.conn
+
+
+class ConnectionPoolMetrics:
+    """Track connection pool statistics."""
+    
+    def __init__(self) -> None:
+        self._connections_created: int = 0
+        self._connections_reused: int = 0
+        self._lock = threading.Lock()
+    
+    def record_creation(self) -> None:
+        with self._lock:
+            self._connections_created += 1
+    
+    def record_reuse(self) -> None:
+        with self._lock:
+            self._connections_reused += 1
+    
+    @property
+    def reuse_ratio(self) -> float:
+        total = self._connections_created + self._connections_reused
+        return self._connections_reused / total if total > 0 else 0.0
+```
+
+### PRAGMA Settings Explained
+
+| PRAGMA | Value | Purpose |
+|--------|-------|---------|
+| `journal_mode` | WAL | Write-Ahead Logging for concurrent reads |
+| `busy_timeout` | 5000 | Wait 5s for locks before failing |
+| `cache_size` | -64000 | 64MB page cache (negative = KB) |
+| `temp_store` | MEMORY | Temp tables in RAM |
+| `mmap_size` | 268435456 | 256MB memory-mapped I/O |
+| `synchronous` | NORMAL | Balance safety/performance (WAL-safe) |
+| `foreign_keys` | ON | Enforce referential integrity |
+
+---
+
+## Implementation Steps
+
+### Phase 1: Add Missing Indexes (Low Risk)
+
+**Estimated Time:** 1 hour
+
+1. Create migration file:
+   ```bash
+   # src/infrastructure/persistence/migrations/006_add_missing_indexes.sql
+   ```
+
+2. Migration content:
+   ```sql
+   -- Up
+   CREATE INDEX IF NOT EXISTS idx_telemetry_events_parent_id 
+       ON telemetry_events(parent_event_id);
+   
+   CREATE INDEX IF NOT EXISTS idx_telemetry_events_unprocessed 
+       ON telemetry_events(timestamp, event_type) 
+       WHERE processed_at IS NULL;
+   
+   -- Down
+   DROP INDEX IF EXISTS idx_telemetry_events_parent_id;
+   DROP INDEX IF EXISTS idx_telemetry_events_unprocessed;
+   ```
+
+3. Update migration runner in `src/infrastructure/persistence/migrations/runner.py`
+
+4. Test with:
+   ```bash
+   uv run pytest tests/integration/test_migrations.py -v
+   ```
+
+### Phase 2: Add Performance PRAGMAs (Low Risk)
+
+**Estimated Time:** 30 minutes
+
+1. Extend `DatabaseConfig` in `src/infrastructure/persistence/database.py`
+
+2. Update `get_connection()` to apply PRAGMAs
+
+3. Add configuration options to `config/agent_config.json`
+
+4. Test with:
+   ```bash
+   uv run pytest tests/integration/test_database.py -v
+   ```
+
+### Phase 3: Add Batch Operations (Medium Risk)
+
+**Estimated Time:** 2 hours
+
+1. Add `save_batch()` to `ObservationRepository`
+
+2. Add `delete_batch()` to `ObservationRepository`
+
+3. Update `CleanupService` to use batch operations
+
+4. Add tests:
+   ```bash
+   # tests/unit/infrastructure/test_observation_repository.py
+   def test_save_batch():
+       ...
+   
+   def test_delete_batch():
+       ...
+   ```
+
+### Phase 4: Add Metadata Indexes (Medium Risk)
+
+**Estimated Time:** 2 hours
+
+1. Create migration for generated column:
+   ```sql
+   -- 007_add_metadata_type_column.sql
+   ALTER TABLE observations ADD COLUMN metadata_type TEXT 
+       GENERATED ALWAYS AS (json_extract(metadata, '$.type')) STORED;
+   
+   CREATE INDEX idx_observations_metadata_type ON observations(metadata_type);
+   ```
+
+2. Add `search_by_metadata_type()` to repository
+
+3. Update CLI to support `--filter type=...`
+
+4. Test with:
+   ```bash
+   uv run pytest tests/integration/test_metadata_search.py -v
+   ```
+
+### Phase 5: Remove Redundant Indexes (Low Risk)
+
+**Estimated Time:** 30 minutes
+
+1. Wait for telemetry activation
+
+2. Verify composite indexes are being used:
+   ```sql
+   EXPLAIN QUERY PLAN SELECT * FROM telemetry_events WHERE session_id = 'x';
+   ```
+
+3. Create migration to drop redundant indexes:
+   ```sql
+   -- 008_remove_redundant_indexes.sql
+   DROP INDEX IF EXISTS idx_telemetry_events_session_id;
+   DROP INDEX IF EXISTS idx_telemetry_events_event_type;
+   DROP INDEX IF EXISTS idx_telemetry_events_timestamp;
+   ```
+
+---
+
+## Success Metrics
+
+| Metric | Current | Target | Measurement Method |
+|--------|---------|--------|-------------------|
+| UUID lookup time | 0.02ms | ≤0.02ms | Benchmark: 1000 iterations |
+| FTS search time | 0.28ms | ≤0.25ms | Benchmark: 1000 iterations |
+| Batch insert (100 records) | ~50ms | ≤10ms | Benchmark: 100 iterations |
+| Database size | 184KB | ≤200KB | File size after 90 days |
+| Cleanup time (1000 records) | N/A | ≤100ms | Benchmark: cleanup service |
+| Connection reuse ratio | N/A | ≥95% | Pool metrics tracking |
+| Slow query count | N/A | 0 queries >100ms | Query logger stats |
+
+### Performance Benchmark Code
+
+```python
+# tests/integration/test_database_performance.py
+
+import time
+import uuid
+from pathlib import Path
+import sqlite3
+import pytest
+
+class TestDatabasePerformance:
+    """Performance benchmarks for database operations."""
+    
+    @pytest.fixture
+    def db_path(self, tmp_path: Path) -> Path:
+        return tmp_path / "test_perf.db"
+    
+    @pytest.fixture
+    def populated_db(self, db_path: Path) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("""
+            CREATE TABLE observations (
+                id TEXT PRIMARY KEY,
+                content TEXT NOT NULL,
+                metadata TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )
+        """)
+        conn.execute("CREATE INDEX idx_obs_created ON observations(created_at)")
+        
+        # Insert 1000 test records
+        for i in range(1000):
+            conn.execute(
+                "INSERT INTO observations VALUES (?, ?, ?, ?, ?)",
+                (str(uuid.uuid4()), f"Content {i}", '{"type": "test"}', 
+                 "2026-01-01T00:00:00", "2026-01-01T00:00:00")
+            )
+        conn.commit()
+        return conn
+    
+    def test_uuid_lookup_performance(self, populated_db: sqlite3.Connection) -> None:
+        """Benchmark UUID lookup time."""
+        cursor = populated_db.execute("SELECT id FROM observations LIMIT 1")
+        test_id = cursor.fetchone()[0]
+        
+        start = time.perf_counter()
+        for _ in range(1000):
+            populated_db.execute("SELECT * FROM observations WHERE id = ?", (test_id,))
+        elapsed = time.perf_counter() - start
+        
+        avg_ms = (elapsed / 1000) * 1000
+        assert avg_ms <= 0.02, f"UUID lookup too slow: {avg_ms:.3f}ms"
+    
+    def test_batch_insert_performance(self, db_path: Path) -> None:
+        """Benchmark batch insert time."""
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("""
+            CREATE TABLE observations (
+                id TEXT PRIMARY KEY,
+                content TEXT NOT NULL,
+                metadata TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )
+        """)
+        
+        observations = [
+            (str(uuid.uuid4()), f"Content {i}", '{}', "2026-01-01T00:00:00", "2026-01-01T00:00:00")
+            for i in range(100)
+        ]
+        
+        start = time.perf_counter()
+        with conn:
+            conn.executemany(
+                "INSERT INTO observations VALUES (?, ?, ?, ?, ?)",
+                observations
+            )
+        elapsed = time.perf_counter() - start
+        
+        assert elapsed * 1000 <= 10, f"Batch insert too slow: {elapsed*1000:.1f}ms"
+```
+
+---
+
+## Rollback Plan
+
+### Rollback for Index Changes
+
+```sql
+-- Rollback Phase 1 indexes
+DROP INDEX IF EXISTS idx_telemetry_events_parent_id;
+DROP INDEX IF EXISTS idx_telemetry_events_unprocessed;
+
+-- Rollback Phase 4 indexes
+DROP INDEX IF EXISTS idx_observations_metadata_type;
+
+-- Restore dropped indexes (Phase 5)
+CREATE INDEX IF NOT EXISTS idx_telemetry_events_session_id ON telemetry_events(session_id);
+CREATE INDEX IF NOT EXISTS idx_telemetry_events_event_type ON telemetry_events(event_type);
+CREATE INDEX IF NOT EXISTS idx_telemetry_events_timestamp ON telemetry_events(timestamp);
+```
+
+### Rollback for PRAGMA Changes
+
+1. Revert `DatabaseConfig` to original values:
+   ```python
+   class DatabaseConfig(BaseModel):
+       db_path: Path
+       # Remove performance PRAGMAs
+       model_config = {"frozen": True}
+   ```
+
+2. Restart application to apply new connection settings
+
+### Rollback for Batch Operations
+
+1. Remove `save_batch()` and `delete_batch()` from `ObservationRepository`
+2. Revert `CleanupService` to use single-record operations
+3. No database changes required
+
+### Rollback for Generated Columns
+
+```sql
+-- Remove generated column (requires table rebuild)
+CREATE TABLE observations_new (
+    id TEXT PRIMARY KEY,
+    content TEXT NOT NULL,
+    metadata TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+INSERT INTO observations_new SELECT id, content, metadata, created_at, updated_at FROM observations;
+
+DROP TABLE observations;
+ALTER TABLE observations_new RENAME TO observations;
+
+-- Recreate indexes and triggers
+CREATE INDEX idx_observations_created_at ON observations(created_at);
+-- ... other indexes
+```
+
+### Emergency Rollback Script
+
+```bash
+#!/bin/bash
+# scripts/rollback-database-optimizations.sh
+
+set -e
+
+DB_PATH="${1:-memory.db}"
+BACKUP_PATH="${DB_PATH}.backup-$(date +%Y%m%d_%H%M%S)"
+
+echo "Creating backup at $BACKUP_PATH"
+cp "$DB_PATH" "$BACKUP_PATH"
+
+echo "Rolling back database optimizations..."
+
+sqlite3 "$DB_PATH" <<EOF
+-- Drop new indexes
+DROP INDEX IF EXISTS idx_telemetry_events_parent_id;
+DROP INDEX IF EXISTS idx_telemetry_events_unprocessed;
+DROP INDEX IF EXISTS idx_observations_metadata_type;
+
+-- Restore removed indexes
+CREATE INDEX IF NOT EXISTS idx_telemetry_events_session_id ON telemetry_events(session_id);
+CREATE INDEX IF NOT EXISTS idx_telemetry_events_event_type ON telemetry_events(event_type);
+CREATE INDEX IF NOT EXISTS idx_telemetry_events_timestamp ON telemetry_events(timestamp);
+
+-- Verify integrity
+PRAGMA integrity_check;
+EOF
+
+echo "Rollback complete. Backup preserved at $BACKUP_PATH"
+```
+
+---
+
+## Architecture Diagram
+
+```mermaid
+flowchart TB
+    subgraph Domain["Domain Layer"]
+        entities["Entities<br/>Observation, ScheduledTask<br/>TelemetryEvent, TelemetryMetric"]
+        ports["Ports (Protocols)<br/>ObservationRepository<br/>TelemetryRepository"]
+    end
+    
+    subgraph Application["Application Layer"]
+        services["Services<br/>MemoryService, CleanupService<br/>TelemetryService, SchedulerService"]
+        usecases["Use Cases<br/>SaveObservation, SearchObservations<br/>ListObservations, DeleteObservation"]
+    end
+    
+    subgraph Infrastructure["Infrastructure Layer"]
+        dbconn["Database Connection<br/>Thread-local + WAL mode<br/>Performance PRAGMAs"]
+        repos["Repositories<br/>ObservationRepository<br/>TelemetryRepository"]
+        migrations["Migrations<br/>001-008 migrations<br/>Version tracking"]
+        querylog["Query Logger<br/>Slow query detection<br/>Statistics collection"]
+        health["Health Check<br/>Integrity verification<br/>FTS sync validation"]
+        cleanup["Cleanup Service<br/>TTL-based deletion<br/>Batch operations"]
+    end
+    
+    subgraph Database["SQLite Database"]
+        obs_table["observations<br/>52 rows"]
+        fts_table["observations_fts<br/>FTS5 virtual table"]
+        telem_tables["telemetry_events<br/>telemetry_metrics<br/>telemetry_sessions<br/>(0 rows)"]
+        tasks_table["scheduled_tasks<br/>(0 rows)"]
+    end
+    
+    services --> usecases
+    usecases --> ports
+    ports --> repos
+    repos --> dbconn
+    dbconn --> Database
+    migrations --> Database
+    querylog --> dbconn
+    health --> Database
+    cleanup --> repos
+```
+
+---
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `src/infrastructure/persistence/database.py` | Add performance PRAGMAs to `DatabaseConfig` and `get_connection()` |
+| `src/infrastructure/persistence/repositories/observation_repository.py` | Add `save_batch()`, `delete_batch()`, `search_by_metadata_type()` |
+| `src/infrastructure/persistence/migrations/006_add_missing_indexes.sql` | Create migration for telemetry indexes |
+| `src/infrastructure/persistence/migrations/007_add_metadata_type_column.sql` | Create migration for metadata generated column |
+| `src/infrastructure/persistence/migrations/008_remove_redundant_indexes.sql` | Create migration to drop redundant indexes |
+| `src/application/services/cleanup_service.py` | Update to use batch operations |
+| `src/interfaces/cli/commands/list.py` | Add `--filter` option for metadata type |
+| `config/agent_config.json` | Add database performance settings |
+| `tests/integration/test_database_performance.py` | Add performance benchmarks |
+| `tests/integration/test_migrations.py` | Add tests for new migrations |
+
+---
+
+## Recommendations Summary
+
+### Immediate (This Sprint)
+
+1. **Add missing indexes** - Low risk, immediate benefit for telemetry
+2. **Add performance PRAGMAs** - Low risk, measurable improvement
+3. **Add batch operations** - Medium risk, essential for cleanup performance
+
+### Short-term (Next Sprint)
+
+4. **Add metadata generated columns** - Enables efficient metadata filtering
+5. **Optimize telemetry queries** - Prepare for telemetry feature activation
+
+### Long-term (Future)
+
+6. **Database archiving** - Move old observations to archive table
+7. **Read replicas** - For analytics workloads
+8. **Connection pool monitoring** - Track connection health and reuse
 
 ---
 
@@ -45,7 +761,7 @@
 
 ---
 
-## Files Created/Modified
+## Files Created/Modified (Previous Phase)
 
 ### Created
 - `src/application/services/cleanup_service.py`

--- a/src/application/services/cleanup_service.py
+++ b/src/application/services/cleanup_service.py
@@ -1,0 +1,106 @@
+"""Cleanup service for managing old observations."""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from dataclasses import dataclass
+
+from src.infrastructure.persistence.database import DatabaseConnection
+
+
+@dataclass(frozen=True)
+class CleanupResult:
+    """Result of a cleanup operation."""
+
+    deleted_count: int
+    fts_deleted_count: int
+
+
+class CleanupService:
+    """Service for cleaning up old observations and maintaining database."""
+
+    __slots__ = ("_connection",)
+
+    def __init__(self, connection: DatabaseConnection) -> None:
+        self._connection = connection
+
+    def cleanup_old_observations(self, days: int = 90, dry_run: bool = False) -> CleanupResult:
+        """Delete observations older than specified days.
+
+        Args:
+            days: Number of days to keep. Default is 90.
+            dry_run: If True, only count records without deleting.
+
+        Returns:
+            CleanupResult with counts of deleted records.
+        """
+        cutoff_timestamp = self._calculate_cutoff_timestamp(days)
+
+        if dry_run:
+            return self._count_old_observations(cutoff_timestamp)
+
+        return self._delete_old_observations(cutoff_timestamp)
+
+    def vacuum_database(self) -> None:
+        """Run VACUUM to reclaim disk space after deletions."""
+        try:
+            with self._connection as conn:
+                conn.execute("VACUUM")
+        except sqlite3.Error as e:
+            raise RuntimeError(f"Failed to vacuum database: {e}") from e
+
+    def optimize_fts(self) -> None:
+        """Optimize FTS5 index after bulk operations."""
+        try:
+            with self._connection as conn:
+                conn.execute("INSERT INTO observations_fts(observations_fts) VALUES('optimize')")
+        except sqlite3.Error as e:
+            raise RuntimeError(f"Failed to optimize FTS: {e}") from e
+
+    def _calculate_cutoff_timestamp(self, days: int) -> int:
+        """Calculate the cutoff timestamp for deletion."""
+        return int((time.time() - (days * 86400)) * 1000)
+
+    def _count_old_observations(self, cutoff_timestamp: int) -> CleanupResult:
+        """Count old observations without deleting."""
+        try:
+            with self._connection as conn:
+                cursor = conn.execute(
+                    "SELECT COUNT(*) FROM observations WHERE timestamp < ?",
+                    (cutoff_timestamp,),
+                )
+                deleted_count = cursor.fetchone()[0]
+
+                fts_cursor = conn.execute(
+                    """SELECT COUNT(*) FROM observations o
+                       WHERE o.timestamp < ?
+                       AND EXISTS (SELECT 1 FROM observations_fts fts WHERE fts.rowid = o.rowid)""",
+                    (cutoff_timestamp,),
+                )
+                fts_deleted_count = fts_cursor.fetchone()[0]
+
+            return CleanupResult(deleted_count=deleted_count, fts_deleted_count=fts_deleted_count)
+        except sqlite3.Error as e:
+            raise RuntimeError(f"Failed to count old observations: {e}") from e
+
+    def _delete_old_observations(self, cutoff_timestamp: int) -> CleanupResult:
+        """Delete old observations from both observations and FTS tables."""
+        try:
+            with self._connection as conn:
+                cursor = conn.execute(
+                    "DELETE FROM observations WHERE timestamp < ?",
+                    (cutoff_timestamp,),
+                )
+                deleted_count = cursor.rowcount
+
+                fts_cursor = conn.execute(
+                    """DELETE FROM observations_fts
+                       WHERE rowid IN (SELECT rowid FROM observations WHERE timestamp < ?)""",
+                    (cutoff_timestamp,),
+                )
+                fts_deleted_count = fts_cursor.rowcount
+
+            return CleanupResult(deleted_count=deleted_count, fts_deleted_count=fts_deleted_count)
+        except sqlite3.Error as e:
+            raise RuntimeError(f"Failed to delete old observations: {e}") from e

--- a/src/application/services/memory_service.py
+++ b/src/application/services/memory_service.py
@@ -37,9 +37,8 @@ class MemoryService:
     def search(self, query: str, limit: int | None = None) -> list[Observation]:
         return self._repository.search(query, limit=limit)
 
-    def get_recent(self, limit: int = 10) -> list[Observation]:
-        all_observations = self._repository.get_all()
-        return all_observations[:limit]
+    def get_recent(self, limit: int = 10, offset: int = 0) -> list[Observation]:
+        return self._repository.get_all(limit=limit, offset=offset)
 
     def get_by_id(self, observation_id: str) -> Observation:
         return self._repository.get_by_id(observation_id)

--- a/src/application/services/workflow/goal_analyzer.py
+++ b/src/application/services/workflow/goal_analyzer.py
@@ -1,0 +1,175 @@
+"""Goal analysis service for deriving requirements from goals."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from src.domain.entities.derived_requirement import (
+    DerivedRequirement,
+    RequirementPriority,
+    RequirementSource,
+)
+from src.domain.entities.goal import Goal
+
+
+def slugify(text: str) -> str:
+    """Convert text to a slug-friendly identifier."""
+    text = text.lower()
+    text = re.sub(r"[^\w\s-]", "", text)
+    text = re.sub(r"[\s_-]+", "-", text)
+    text = text.strip("-")
+    return text
+
+
+class GoalAnalysisError(Exception):
+    """Raised when goal analysis fails to produce requirements."""
+
+    pass
+
+
+class GoalAnalyzer:
+    """Analyzes goals to derive implicit requirements."""
+
+    # Keyword-based derivation rules
+    DERIVATION_RULES = {
+        frozenset(["api", "rest", "endpoint", "http"]): [
+            ("error-handling", "Error handling for all endpoints", RequirementPriority.MUST),
+            ("input-validation", "Input validation", RequirementPriority.MUST),
+            ("status-codes", "Proper HTTP status codes", RequirementPriority.MUST),
+            ("api-documentation", "API documentation", RequirementPriority.NICE),
+        ],
+        frozenset(["auth", "login", "password", "jwt", "token"]): [
+            ("password-hashing", "Secure password hashing", RequirementPriority.MUST),
+            ("session-management", "Session management", RequirementPriority.MUST),
+            ("password-reset", "Password reset functionality", RequirementPriority.NICE),
+            ("two-factor", "Two-factor authentication", RequirementPriority.NICE),
+        ],
+        frozenset(["payment", "stripe", "checkout", "transaction"]): [
+            ("webhook-handling", "Webhook handling", RequirementPriority.MUST),
+            ("receipt-generation", "Receipt generation", RequirementPriority.NICE),
+            ("refund-handling", "Refund processing", RequirementPriority.NICE),
+            ("payment-logging", "Payment transaction logging", RequirementPriority.MUST),
+        ],
+        frozenset(["database", "db", "sql", "postgres", "mysql"]): [
+            ("database-migrations", "Database migrations", RequirementPriority.MUST),
+            ("connection-pooling", "Connection pooling", RequirementPriority.MUST),
+            ("backup-strategy", "Backup strategy", RequirementPriority.NICE),
+        ],
+        frozenset(["frontend", "ui", "web", "react", "vue"]): [
+            ("responsive-design", "Responsive design", RequirementPriority.MUST),
+            ("accessibility", "Accessibility (a11y)", RequirementPriority.NICE),
+            ("loading-states", "Loading states", RequirementPriority.NICE),
+            ("error-messages", "User-friendly error messages", RequirementPriority.MUST),
+        ],
+        frozenset(["email", "notification"]): [
+            ("email-templates", "Email templates", RequirementPriority.MUST),
+            ("unsubscribe-handling", "Unsubscribe handling", RequirementPriority.MUST),
+            ("email-deliverability", "Email deliverability", RequirementPriority.NICE),
+        ],
+        frozenset(["file", "upload", "storage", "s3"]): [
+            ("file-validation", "File validation", RequirementPriority.MUST),
+            ("storage-cleanup", "Storage cleanup", RequirementPriority.NICE),
+            ("upload-progress", "Upload progress tracking", RequirementPriority.NICE),
+        ],
+        frozenset(["security", "encryption", "crypto"]): [
+            ("encryption-at-rest", "Encryption at rest", RequirementPriority.MUST),
+            ("encryption-in-transit", "Encryption in transit (TLS)", RequirementPriority.MUST),
+            ("audit-logging", "Audit logging", RequirementPriority.MUST),
+            ("security-headers", "Security headers", RequirementPriority.MUST),
+        ],
+    }
+
+    def analyze(self, goal: Goal | None) -> list[DerivedRequirement]:
+        """Derive requirements from goal and explicit requirements.
+
+        Args:
+            goal: The goal to analyze, or None for backward compatibility.
+
+        Returns:
+            List of derived requirements.
+
+        Raises:
+            GoalAnalysisError: If no requirements are produced.
+        """
+        if goal is None:
+            return []
+
+        requirements = []
+
+        # 1. Start with must_haves as explicit requirements
+        for must_have in goal.must_haves:
+            req_id = slugify(must_have)
+            # Avoid duplicates
+            if not any(r.id == req_id for r in requirements):
+                requirements.append(
+                    DerivedRequirement(
+                        id=req_id,
+                        description=must_have,
+                        source=RequirementSource.EXPLICIT,
+                        priority=RequirementPriority.MUST,
+                    )
+                )
+
+        # 2. Add nice-to-haves
+        for nice in goal.nice_to_haves:
+            req_id = slugify(nice)
+            if not any(r.id == req_id for r in requirements):
+                requirements.append(
+                    DerivedRequirement(
+                        id=req_id,
+                        description=nice,
+                        source=RequirementSource.EXPLICIT,
+                        priority=RequirementPriority.NICE,
+                    )
+                )
+
+        # 3. Analyze goal for implicit requirements
+        implicit = self._derive_implicit(goal)
+        for req in implicit:
+            if not any(r.id == req.id for r in requirements):
+                requirements.append(req)
+
+        # CRITICAL: Validate we have at least some requirements
+        if not requirements:
+            raise GoalAnalysisError(
+                "Goal analysis produced no requirements. "
+                "Please provide at least one --must-have or use a more descriptive goal."
+            )
+
+        return requirements
+
+    def _derive_implicit(self, goal: Goal) -> list[DerivedRequirement]:
+        """Derive implicit requirements from goal text.
+
+        Args:
+            goal: The goal to analyze.
+
+        Returns:
+            List of implicitly derived requirements.
+        """
+        implicit: list[DerivedRequirement] = []
+        objective_lower = goal.objective.lower()
+
+        # Check each keyword group
+        for keywords, reqs in self.DERIVATION_RULES.items():
+            # Check if any keyword matches
+            if any(kw in objective_lower for kw in keywords):
+                for req_id, desc, priority in reqs:
+                    # Check if not already explicitly provided
+                    explicit_ids = {slugify(m) for m in goal.must_haves}
+                    explicit_ids |= {slugify(n) for n in goal.nice_to_haves}
+
+                    if req_id not in explicit_ids:
+                        # Check if not already added
+                        if not any(r.id == req_id for r in implicit):
+                            implicit.append(
+                                DerivedRequirement(
+                                    id=req_id,
+                                    description=desc,
+                                    source=RequirementSource.DERIVED,
+                                    priority=priority,
+                                )
+                            )
+
+        return implicit

--- a/src/application/services/workflow/state.py
+++ b/src/application/services/workflow/state.py
@@ -1,7 +1,8 @@
 """Workflow state management.
 
 State Schema Versioning:
-- v2 (current): Includes decisions field in PlanState
+- v3 (current): Includes goal and derived_requirements in PlanState
+- v2 (legacy): Includes decisions field in PlanState
 - v1 (legacy): No decisions field - auto-migrated on load
 - v0 (legacy): No schema_version field - auto-migrated on load
 """
@@ -13,11 +14,17 @@ from datetime import datetime
 from enum import Enum
 from pathlib import Path
 
+from src.domain.entities.derived_requirement import (
+    DerivedRequirement,
+    RequirementPriority,
+    RequirementSource,
+)
+from src.domain.entities.goal import Goal
 from src.domain.entities.user_decision import DecisionStatus, UserDecision
 
 import json
 
-CURRENT_SCHEMA_VERSION = 2
+CURRENT_SCHEMA_VERSION = 3
 
 
 class StateError(Exception):
@@ -53,6 +60,8 @@ class Task:
     worktree_path: str | None = None
     session_name: str | None = None
     agent_pid: int | None = None
+    depends_on: tuple[str, ...] = ()
+    requirement_ids: tuple[str, ...] = ()
 
 
 @dataclass
@@ -64,6 +73,8 @@ class PlanState:
     plan_file: str = ".claude/plans/plan.md"
     tasks: list[Task] = field(default_factory=list)
     decisions: dict[str, UserDecision] = field(default_factory=dict)
+    goal: Goal | None = None
+    derived_requirements: tuple[DerivedRequirement, ...] = ()
     schema_version: int = CURRENT_SCHEMA_VERSION
     migrated_from: int | None = None
 
@@ -86,6 +97,8 @@ class PlanState:
                     "worktree_path": t.worktree_path,
                     "session_name": t.session_name,
                     "agent_pid": t.agent_pid,
+                    "depends_on": list(t.depends_on),
+                    "requirement_ids": list(t.requirement_ids),
                 }
                 for t in self.tasks
             ],
@@ -98,6 +111,24 @@ class PlanState:
                 }
                 for k, d in self.decisions.items()
             },
+            "goal": {
+                "objective": self.goal.objective,
+                "must_haves": list(self.goal.must_haves),
+                "nice_to_haves": list(self.goal.nice_to_haves),
+                "scope_in": list(self.goal.scope_in),
+                "scope_out": list(self.goal.scope_out),
+            }
+            if self.goal
+            else None,
+            "derived_requirements": [
+                {
+                    "id": r.id,
+                    "description": r.description,
+                    "source": r.source.value,
+                    "priority": r.priority.value,
+                }
+                for r in self.derived_requirements
+            ],
         }
 
     @classmethod
@@ -125,8 +156,13 @@ class PlanState:
         if schema_version == 1:
             migrated_from = 1
 
-        schema_version = 2  # Always use current version
+        # Migration: v2 -> v3 (add goal and derived_requirements)
+        if schema_version == 2:
+            migrated_from = 2
 
+        schema_version = 3  # Always use current version
+
+        # Parse tasks with new fields
         tasks = [
             Task(
                 id=t["id"],
@@ -137,6 +173,8 @@ class PlanState:
                 worktree_path=t.get("worktree_path"),
                 session_name=t.get("session_name"),
                 agent_pid=t.get("agent_pid"),
+                depends_on=tuple(t.get("depends_on", [])),
+                requirement_ids=tuple(t.get("requirement_ids", [])),
             )
             for t in data.get("tasks", [])
         ]
@@ -152,6 +190,32 @@ class PlanState:
                 rationale=d.get("rationale"),
             )
 
+        # Parse goal (new in v3)
+        goal: Goal | None = None
+        goal_data = data.get("goal")
+        if goal_data:
+            goal = Goal(
+                objective=goal_data["objective"],
+                must_haves=tuple(goal_data.get("must_haves", [])),
+                nice_to_haves=tuple(goal_data.get("nice_to_haves", [])),
+                scope_in=tuple(goal_data.get("scope_in", [])),
+                scope_out=tuple(goal_data.get("scope_out", [])),
+            )
+
+        # Parse derived_requirements (new in v3)
+        derived_requirements: tuple[DerivedRequirement, ...] = ()
+        req_data = data.get("derived_requirements", [])
+        if req_data:
+            derived_requirements = tuple(
+                DerivedRequirement(
+                    id=r["id"],
+                    description=r["description"],
+                    source=RequirementSource(r["source"]),
+                    priority=RequirementPriority(r["priority"]),
+                )
+                for r in req_data
+            )
+
         return cls(
             session_id=data["session_id"],
             status=data.get("status", "planning"),
@@ -160,6 +224,8 @@ class PlanState:
             plan_file=data.get("plan_file", ".claude/plans/plan.md"),
             tasks=tasks,
             decisions=decisions,
+            goal=goal,
+            derived_requirements=derived_requirements,
             schema_version=schema_version,
             migrated_from=migrated_from,
         )
@@ -198,6 +264,8 @@ class PlanState:
             plan_file=self.plan_file,
             tasks=self.tasks,
             decisions=new_decisions,
+            goal=self.goal,
+            derived_requirements=self.derived_requirements,
             schema_version=self.schema_version,
             migrated_from=self.migrated_from,
         )
@@ -236,6 +304,8 @@ class ExecuteState:
                     "worktree_path": t.worktree_path,
                     "session_name": t.session_name,
                     "agent_pid": t.agent_pid,
+                    "depends_on": list(t.depends_on),
+                    "requirement_ids": list(t.requirement_ids),
                 }
                 for t in self.tasks
             ],
@@ -257,7 +327,7 @@ class ExecuteState:
         migrated_from: int | None = None
         if schema_version == 0:
             migrated_from = 0
-            schema_version = 2
+            schema_version = 3
 
         tasks = [
             Task(
@@ -269,6 +339,8 @@ class ExecuteState:
                 worktree_path=t.get("worktree_path"),
                 session_name=t.get("session_name"),
                 agent_pid=t.get("agent_pid"),
+                depends_on=tuple(t.get("depends_on", [])),
+                requirement_ids=tuple(t.get("requirement_ids", [])),
             )
             for t in data.get("tasks", [])
         ]
@@ -347,7 +419,7 @@ class VerifyState:
         migrated_from: int | None = None
         if schema_version == 0:
             migrated_from = 0
-            schema_version = 2
+            schema_version = 3
 
         return cls(
             session_id=data["session_id"],

--- a/src/application/services/workflow/task_decomposer.py
+++ b/src/application/services/workflow/task_decomposer.py
@@ -1,0 +1,223 @@
+"""Task decomposition service for breaking goals into ordered tasks."""
+
+from __future__ import annotations
+
+import uuid
+
+from src.application.services.workflow.state import Task
+from src.domain.entities.derived_requirement import DerivedRequirement, RequirementPriority
+from src.domain.entities.goal import Goal
+
+
+def slugify(text: str) -> str:
+    """Convert text to a slug-friendly identifier."""
+    import re
+
+    text = text.lower()
+    text = re.sub(r"[^\w\s-]", "", text)
+    text = re.sub(r"[\s_-]+", "-", text)
+    text = text.strip("-")
+    return text
+
+
+class CircularDependencyError(Exception):
+    """Raised when task dependencies form a cycle."""
+
+    pass
+
+
+class TaskDecomposer:
+    """Decomposes goals into ordered tasks with dependency tracking."""
+
+    def decompose(
+        self,
+        goal: Goal,
+        requirements: list[DerivedRequirement],
+    ) -> list[Task]:
+        """Decompose goal into ordered tasks.
+
+        Args:
+            goal: The goal to decompose.
+            requirements: The requirements derived from the goal.
+
+        Returns:
+            Ordered list of tasks with dependencies.
+
+        Raises:
+            CircularDependencyError: If circular dependencies are detected.
+        """
+        tasks: list[Task] = []
+
+        # Separate must-have vs nice-to-have requirements
+        must_reqs = [r for r in requirements if r.priority == RequirementPriority.MUST]
+        nice_reqs = [r for r in requirements if r.priority == RequirementPriority.NICE]
+
+        # Phase 1: Foundation tasks (setup, config)
+        foundation_tasks = self._create_foundation_tasks(goal)
+        tasks.extend(foundation_tasks)
+
+        # Phase 2: Core tasks (from must-have requirements)
+        core_tasks = self._create_core_tasks(must_reqs, foundation_tasks)
+        tasks.extend(core_tasks)
+
+        # Phase 3: Integration tasks
+        integration_tasks = self._create_integration_tasks(goal, core_tasks)
+        tasks.extend(integration_tasks)
+
+        # Phase 4: Optional tasks (nice-to-haves)
+        if nice_reqs:
+            optional_tasks = self._create_optional_tasks(nice_reqs, core_tasks)
+            tasks.extend(optional_tasks)
+
+        # Phase 5: Add the main task
+        main_task = Task(
+            id=f"task-{uuid.uuid4().hex[:8]}",
+            slug=slugify(goal.objective),
+            description=goal.objective,
+            status="pending",
+            requirement_ids=tuple(r.id for r in requirements),
+            depends_on=tuple(t.id for t in core_tasks if t.id),
+        )
+        tasks.append(main_task)
+
+        # CRITICAL: Validate no circular dependencies
+        self._validate_dependencies(tasks)
+
+        return tasks
+
+    def _create_foundation_tasks(self, goal: Goal) -> list[Task]:
+        """Create foundation/setup tasks."""
+        tasks = []
+
+        # Task: Project setup
+        setup_task = Task(
+            id=f"task-{uuid.uuid4().hex[:8]}",
+            slug="project-setup",
+            description="Set up project structure and dependencies",
+            status="pending",
+            depends_on=(),
+            requirement_ids=(),
+        )
+        tasks.append(setup_task)
+
+        return tasks
+
+    def _create_core_tasks(
+        self,
+        requirements: list[DerivedRequirement],
+        foundation_tasks: list[Task],
+    ) -> list[Task]:
+        """Create core tasks from requirements."""
+        tasks = []
+        foundation_ids = tuple(t.id for t in foundation_tasks)
+
+        for req in requirements:
+            task = Task(
+                id=f"task-{uuid.uuid4().hex[:8]}",
+                slug=req.id,
+                description=req.description,
+                status="pending",
+                depends_on=foundation_ids,
+                requirement_ids=(req.id,),
+            )
+            tasks.append(task)
+
+        return tasks
+
+    def _create_integration_tasks(
+        self,
+        goal: Goal,
+        core_tasks: list[Task],
+    ) -> list[Task]:
+        """Create integration tasks."""
+        tasks = []
+
+        if not core_tasks:
+            return tasks
+
+        core_ids = tuple(t.id for t in core_tasks)
+
+        # Integration task - depends on all core tasks
+        integration_task = Task(
+            id=f"task-{uuid.uuid4().hex[:8]}",
+            slug="integration",
+            description="Integrate components and verify functionality",
+            status="pending",
+            depends_on=core_ids,
+            requirement_ids=(),
+        )
+        tasks.append(integration_task)
+
+        return tasks
+
+    def _create_optional_tasks(
+        self,
+        requirements: list[DerivedRequirement],
+        core_tasks: list[Task],
+    ) -> list[Task]:
+        """Create optional/nice-to-have tasks."""
+        tasks = []
+
+        if not core_tasks:
+            return tasks
+
+        # These depend on integration being complete
+        integration_id = core_tasks[-1].id if core_tasks else None
+        depends_on = (integration_id,) if integration_id else ()
+
+        for req in requirements:
+            task = Task(
+                id=f"task-{uuid.uuid4().hex[:8]}",
+                slug=req.id,
+                description=req.description,
+                status="pending",
+                depends_on=depends_on,
+                requirement_ids=(req.id,),
+            )
+            tasks.append(task)
+
+        return tasks
+
+    def _validate_dependencies(self, tasks: list[Task]) -> None:
+        """Validate no circular or self-referential dependencies.
+
+        Args:
+            tasks: List of tasks to validate.
+
+        Raises:
+            CircularDependencyError: If circular or self-referential dependencies found.
+        """
+        # Build dependency graph
+        dep_graph: dict[str, set[str]] = {}
+        for task in tasks:
+            dep_graph[task.id] = set(task.depends_on)
+
+        # Check for self-reference
+        for task in tasks:
+            if task.id in dep_graph[task.id]:
+                raise CircularDependencyError(f"Task '{task.id}' depends on itself")
+
+        # Check for cycles using DFS
+        visited: set[str] = set()
+        rec_stack: set[str] = set()
+
+        def has_cycle(node: str) -> bool:
+            visited.add(node)
+            rec_stack.add(node)
+
+            for dep in dep_graph.get(node, set()):
+                if dep not in visited:
+                    if has_cycle(dep):
+                        return True
+                elif dep in rec_stack:
+                    return True
+
+            rec_stack.remove(node)
+            return False
+
+        for task in tasks:
+            if task.id not in visited:
+                if has_cycle(task.id):
+                    raise CircularDependencyError(
+                        f"Circular dependency detected involving task '{task.id}'"
+                    )

--- a/src/domain/entities/__init__.py
+++ b/src/domain/entities/__init__.py
@@ -1,4 +1,28 @@
-"""Entidades del dominio."""
+from src.domain.entities.derived_requirement import (
+    DerivedRequirement,
+    RequirementPriority,
+    RequirementSource,
+)
+from src.domain.entities.goal import Goal
+from src.domain.entities.message import AgentMessage, MessageType
+from src.domain.entities.observation import Observation
+from src.domain.entities.terminal import PlatformType, TerminalConfig, TerminalResult
+from src.domain.entities.user_decision import DecisionStatus, UserDecision
+
+__all__ = [
+    "AgentMessage",
+    "MessageType",
+    "Observation",
+    "PlatformType",
+    "TerminalConfig",
+    "TerminalResult",
+    "DecisionStatus",
+    "UserDecision",
+    "Goal",
+    "DerivedRequirement",
+    "RequirementPriority",
+    "RequirementSource",
+]
 
 from src.domain.entities.message import AgentMessage, MessageType
 from src.domain.entities.observation import Observation

--- a/src/domain/entities/derived_requirement.py
+++ b/src/domain/entities/derived_requirement.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class RequirementPriority(str, Enum):
+    """Requirement priority enum with string values for database persistence."""
+
+    MUST = "must"
+    NICE = "nice"
+
+
+class RequirementSource(str, Enum):
+    """Requirement source enum with string values for database persistence."""
+
+    EXPLICIT = "explicit"
+    DERIVED = "derived"
+
+
+@dataclass(frozen=True)
+class DerivedRequirement:
+    """Immutable derived requirement entity.
+
+    Represents a requirement derived from goal analysis.
+
+    Attributes:
+        id: Unique identifier for the requirement.
+        description: The requirement description.
+        source: Source of the requirement (explicit or derived).
+        priority: Priority level (must or nice).
+    """
+
+    id: str
+    description: str
+    source: RequirementSource
+    priority: RequirementPriority
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.id, str):
+            raise TypeError("id must be a string")
+        if not self.id:
+            raise ValueError("id cannot be empty")
+        if not isinstance(self.description, str):
+            raise TypeError("description must be a string")
+        if not self.description:
+            raise ValueError("description cannot be empty")
+        if not isinstance(self.source, RequirementSource):
+            raise TypeError("source must be a RequirementSource")
+        if not isinstance(self.priority, RequirementPriority):
+            raise TypeError("priority must be a RequirementPriority")

--- a/src/domain/entities/goal.py
+++ b/src/domain/entities/goal.py
@@ -26,6 +26,12 @@ class Goal:
     def __post_init__(self) -> None:
         if not isinstance(self.objective, str):
             raise TypeError("objective must be a string")
+        if not self.objective:
+            raise ValueError("objective cannot be empty")
+        if len(self.objective) > 10000:
+            raise ValueError("objective must not exceed 10000 characters")
+        if not isinstance(self.objective, str):
+            raise TypeError("objective must be a string")
         if len(self.objective) > 10000:
             raise ValueError("objective must not exceed 10000 characters")
         # Validate scope disjointness

--- a/src/domain/entities/goal.py
+++ b/src/domain/entities/goal.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Goal:
+    """Immutable goal entity representing an objective.
+
+    Represents a structured goal with requirements and scope definitions.
+
+    Attributes:
+        objective: The main goal description.
+        must_haves: Non-negotiable requirements.
+        nice_to_haves: Optional enhancements.
+        scope_in: In-scope items.
+        scope_out: Out-of-scope items.
+    """
+
+    objective: str
+    must_haves: tuple[str, ...] = ()
+    nice_to_haves: tuple[str, ...] = ()
+    scope_in: tuple[str, ...] = ()
+    scope_out: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.objective, str):
+            raise TypeError("objective must be a string")
+        if len(self.objective) > 10000:
+            raise ValueError("objective must not exceed 10000 characters")
+        # Validate scope disjointness
+        scope_in_set = set(self.scope_in)
+        scope_out_set = set(self.scope_out)
+        overlap = scope_in_set & scope_out_set
+        if overlap:
+            raise ValueError(f"scope_in and scope_out must be disjoint, found: {overlap}")
+        # Validate collections are tuples
+        if not isinstance(self.must_haves, tuple):
+            raise TypeError("must_haves must be a tuple")
+        if not isinstance(self.nice_to_haves, tuple):
+            raise TypeError("nice_to_haves must be a tuple")
+        if not isinstance(self.scope_in, tuple):
+            raise TypeError("scope_in must be a tuple")
+        if not isinstance(self.scope_out, tuple):
+            raise TypeError("scope_out must be a tuple")

--- a/src/infrastructure/persistence/container.py
+++ b/src/infrastructure/persistence/container.py
@@ -8,6 +8,8 @@ from dependency_injector import containers, providers
 
 from src.application.services.memory_service import MemoryService
 from src.application.services.scheduler_service import SchedulerService
+from src.application.services.cleanup_service import CleanupService
+from src.infrastructure.persistence.health_check import HealthCheckService
 from src.application.services.workspace.entities import LayoutType, WorkspaceConfig
 from src.application.services.workspace.workspace_manager import WorkspaceManager
 from src.infrastructure.persistence.database import DatabaseConfig, DatabaseConnection
@@ -63,6 +65,17 @@ class Container(containers.DeclarativeContainer):
     scheduler_service = providers.Singleton(
         SchedulerService,
         repository=scheduled_task_repository,
+    )
+
+    cleanup_service = providers.Singleton(
+        CleanupService,
+        connection=database_connection,
+    )
+
+    health_check_service = providers.Singleton(
+        HealthCheckService,
+        connection=database_connection,
+        db_path=config.db_path,
     )
 
     tmux_orchestrator = providers.Singleton(

--- a/src/infrastructure/persistence/health_check.py
+++ b/src/infrastructure/persistence/health_check.py
@@ -1,0 +1,152 @@
+"""Health check service for database diagnostics."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+from src.infrastructure.persistence.database import DatabaseConnection
+
+
+@dataclass(frozen=True)
+class HealthCheckResult:
+    """Result of a health check."""
+
+    is_healthy: bool
+    integrity_ok: bool
+    fts_synced: bool
+    observation_count: int
+    fts_count: int
+    db_size_bytes: int
+    issues: list[str]
+
+
+class HealthCheckService:
+    """Service for checking database health."""
+
+    __slots__ = ("_connection", "_db_path")
+
+    def __init__(self, connection: DatabaseConnection, db_path: Path | None = None) -> None:
+        self._connection = connection
+        self._db_path = db_path or Path("data/memory.db")
+
+    def check_health(self, verbose: bool = False) -> HealthCheckResult:
+        """Run full health check on the database.
+
+        Args:
+            verbose: Include detailed information in results.
+
+        Returns:
+            HealthCheckResult with health status and details.
+        """
+        issues: list[str] = []
+
+        # Check integrity
+        integrity_ok = self._check_integrity()
+
+        # Check FTS sync
+        fts_synced, obs_count, fts_count = self._check_fts_sync()
+
+        if not integrity_ok:
+            issues.append("Database integrity check failed")
+
+        if not fts_synced:
+            issues.append(f"FTS desync: {obs_count} observations but {fts_count} FTS entries")
+
+        # Get DB size
+        db_size = self._get_db_size()
+
+        is_healthy = len(issues) == 0
+
+        return HealthCheckResult(
+            is_healthy=is_healthy,
+            integrity_ok=integrity_ok,
+            fts_synced=fts_synced,
+            observation_count=obs_count,
+            fts_count=fts_count,
+            db_size_bytes=db_size,
+            issues=issues,
+        )
+
+    def get_stats(self) -> dict:
+        """Get database statistics.
+
+        Returns:
+            Dictionary with database statistics.
+        """
+        _, obs_count, fts_count = self._check_fts_sync()
+
+        return {
+            "observation_count": obs_count,
+            "fts_count": fts_count,
+            "db_size_bytes": self._get_db_size(),
+            "db_size_human": self._format_bytes(self._get_db_size()),
+        }
+
+    def repair_fts(self) -> int:
+        """Repair FTS index by rebuilding from observations table.
+
+        Returns:
+            Number of entries rebuilt.
+        """
+        try:
+            with self._connection as conn:
+                # Get all observations
+                cursor = conn.execute("SELECT rowid, content FROM observations")
+                observations = cursor.fetchall()
+
+                # Delete all FTS entries
+                conn.execute("DELETE FROM observations_fts")
+
+                # Reinsert all observations
+                for obs in observations:
+                    conn.execute(
+                        "INSERT INTO observations_fts(rowid, content) VALUES (?, ?)",
+                        (obs[0], obs[1]),
+                    )
+
+                return len(observations)
+        except sqlite3.Error as e:
+            raise RuntimeError(f"Failed to repair FTS: {e}") from e
+
+    def _check_integrity(self) -> bool:
+        """Check database integrity."""
+        try:
+            with self._connection as conn:
+                cursor = conn.execute("PRAGMA integrity_check")
+                result = cursor.fetchone()
+                return result[0] == "ok"
+        except sqlite3.Error:
+            return False
+
+    def _check_fts_sync(self) -> tuple[bool, int, int]:
+        """Check if FTS index is synced with observations table."""
+        try:
+            with self._connection as conn:
+                obs_cursor = conn.execute("SELECT COUNT(*) FROM observations")
+                obs_count = obs_cursor.fetchone()[0]
+
+                fts_cursor = conn.execute("SELECT COUNT(*) FROM observations_fts")
+                fts_count = fts_cursor.fetchone()[0]
+
+                return obs_count == fts_count, obs_count, fts_count
+        except sqlite3.Error:
+            return False, 0, 0
+
+    def _get_db_size(self) -> int:
+        """Get database file size in bytes."""
+        try:
+            return self._db_path.stat().st_size if self._db_path.exists() else 0
+        except OSError:
+            return 0
+
+    @staticmethod
+    def _format_bytes(size: int) -> str:
+        """Format bytes to human-readable string."""
+        for unit in ["B", "KB", "MB", "GB"]:
+            if size < 1024:
+                return f"{size:.1f} {unit}"
+            size /= 1024
+        return f"{size:.1f} TB"

--- a/src/infrastructure/persistence/query_logger.py
+++ b/src/infrastructure/persistence/query_logger.py
@@ -1,0 +1,100 @@
+"""Query logging utility for performance monitoring."""
+
+from __future__ import annotations
+
+import logging
+import time
+from functools import wraps
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+
+class QueryLogger:
+    """Logger for tracking slow database queries."""
+
+    def __init__(self, threshold_ms: float = 100.0) -> None:
+        """Initialize query logger.
+
+        Args:
+            threshold_ms: Time in milliseconds above which queries are logged.
+        """
+        self._threshold_ms = threshold_ms
+        self._slow_queries: list[dict[str, Any]] = []
+
+    @property
+    def threshold_ms(self) -> float:
+        """Get the threshold in milliseconds."""
+        return self._threshold_ms
+
+    @threshold_ms.setter
+    def threshold_ms(self, value: float) -> None:
+        """Set the threshold in milliseconds."""
+        self._threshold_ms = value
+
+    def log_query(self, query: str, params: tuple, duration_ms: float) -> None:
+        """Log a query execution.
+
+        Args:
+            query: The SQL query string.
+            params: The query parameters.
+            duration_ms: Execution time in milliseconds.
+        """
+        if duration_ms >= self._threshold_ms:
+            entry = {
+                "query": query[:200],  # Truncate long queries
+                "params": str(params)[:100],
+                "duration_ms": duration_ms,
+            }
+            self._slow_queries.append(entry)
+            logger.warning(
+                "Slow query detected: %s ms - %s",
+                f"{duration_ms:.2f}",
+                query[:100],
+            )
+
+    def get_slow_queries(self) -> list[dict[str, Any]]:
+        """Get list of logged slow queries."""
+        return self._slow_queries.copy()
+
+    def clear(self) -> None:
+        """Clear the slow query log."""
+        self._slow_queries.clear()
+
+    def __len__(self) -> int:
+        """Get count of slow queries."""
+        return len(self._slow_queries)
+
+
+# Global query logger instance
+_query_logger = QueryLogger()
+
+
+def get_query_logger() -> QueryLogger:
+    """Get the global query logger instance."""
+    return _query_logger
+
+
+def log_query_time(query: str) -> Callable:
+    """Decorator to log query execution time.
+
+    Args:
+        query: Description of the query for logging.
+
+    Returns:
+        Decorated function.
+    """
+
+    def decorator(func: Callable) -> Callable:
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            start = time.perf_counter()
+            try:
+                return func(*args, **kwargs)
+            finally:
+                duration_ms = (time.perf_counter() - start) * 1000
+                _query_logger.log_query(query, (), duration_ms)
+
+        return wrapper
+
+    return decorator

--- a/src/interfaces/cli/commands/cleanup.py
+++ b/src/interfaces/cli/commands/cleanup.py
@@ -1,0 +1,63 @@
+"""Cleanup command for CLI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from src.application.services.cleanup_service import CleanupService
+from src.interfaces.cli.dependencies import get_cleanup_service
+
+app = typer.Typer()
+
+DEFAULT_DB_PATH = Path("data/memory.db")
+
+
+def _get_cleanup_service_from_context(ctx: typer.Context) -> CleanupService:
+    """Get cleanup service from typer context."""
+    db_path = DEFAULT_DB_PATH
+    if ctx.parent and ctx.parent.params:
+        db_path = Path(ctx.parent.params.get("db_path", DEFAULT_DB_PATH))
+
+    return get_cleanup_service(db_path)
+
+
+@app.command()
+def cleanup(
+    ctx: typer.Context,
+    days: int = typer.Option(90, "--days", "-d", help="Delete observations older than N days"),
+    dry_run: bool = typer.Option(True, "--dry-run/--no-dry-run", help="Preview only, don't delete"),
+    vacuum: bool = typer.Option(False, "--vacuum", "-v", help="Run VACUUM after deletion to reclaim space"),
+    optimize_fts: bool = typer.Option(False, "--optimize-ft", "-o", help="Optimize FTS index after cleanup"),
+) -> None:
+    """Clean up old observations from the database.
+
+    By default, this runs in dry-run mode to preview what would be deleted.
+    Use --no-dry-run to actually delete observations.
+    """
+    cleanup_service = _get_cleanup_service_from_context(ctx)
+
+    if dry_run:
+        typer.echo(f"🔍 DRY RUN - Preview of observations older than {days} days:")
+        typer.echo("-" * 50)
+
+    result = cleanup_service.cleanup_old_observations(days=days, dry_run=dry_run)
+
+    if dry_run:
+        typer.echo(f"Would delete: {result.deleted_count} observations")
+        typer.echo(f"Would delete from FTS: {result.fts_deleted_count} entries")
+        typer.echo("\n💡 Run with --no-dry-run to actually delete.")
+    else:
+        typer.echo(f"✅ Deleted: {result.deleted_count} observations")
+        typer.echo(f"✅ Deleted from FTS: {result.fts_deleted_count} entries")
+
+        if vacuum:
+            typer.echo("Running VACUUM to reclaim space...")
+            cleanup_service.vacuum_database()
+            typer.echo("✅ VACUUM complete")
+
+        if optimize_fts:
+            typer.echo("Optimizing FTS index...")
+            cleanup_service.optimize_fts()
+            typer.echo("✅ FTS optimization complete")

--- a/src/interfaces/cli/commands/health.py
+++ b/src/interfaces/cli/commands/health.py
@@ -1,0 +1,75 @@
+"""Health check command for CLI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from src.infrastructure.persistence.health_check import HealthCheckService
+from src.interfaces.cli.dependencies import get_health_check_service
+
+app = typer.Typer()
+
+DEFAULT_DB_PATH = Path("data/memory.db")
+
+
+def _get_health_service_from_context(ctx: typer.Context) -> HealthCheckService:
+    """Get health check service from typer context."""
+    db_path = DEFAULT_DB_PATH
+    if ctx.parent and ctx.parent.params:
+        db_path = Path(ctx.parent.params.get("db_path", DEFAULT_DB_PATH))
+
+    return get_health_check_service(db_path)
+
+
+@app.command()
+def health(
+    ctx: typer.Context,
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed information"),
+    fix: bool = typer.Option(False, "--fix", "-f", help="Attempt to fix FTS desync"),
+) -> None:
+    """Check database health and integrity.
+
+    Performs integrity checks and reports on database health.
+    """
+    health_service = _get_health_service_from_context(ctx)
+
+    typer.echo("🔍 Running health checks...")
+    typer.echo("-" * 40)
+
+    result = health_service.check_health(verbose=verbose)
+
+    # Display results
+    typer.echo(f"Database Integrity:     {'✅ OK' if result.integrity_ok else '❌ FAILED'}")
+    typer.echo(f"FTS Index Sync:         {'✅ SYNCED' if result.fts_synced else '❌ DESYNCED'}")
+    typer.echo(f"Observations:           {result.observation_count}")
+    typer.echo(f"FTS Entries:            {result.fts_count}")
+    typer.echo(f"Database Size:          {result.db_size_bytes:,} bytes")
+
+    if result.issues:
+        typer.echo("\n⚠️  Issues found:")
+        for issue in result.issues:
+            typer.echo(f"  - {issue}")
+    else:
+        typer.echo("\n✅ Database is healthy!")
+
+    # Fix FTS if requested
+    if fix and not result.fts_synced:
+        typer.echo("\n🔧 Repairing FTS index...")
+        try:
+            rebuilt = health_service.repair_fts()
+            typer.echo(f"✅ Rebuilt {rebuilt} FTS entries")
+
+            # Recheck
+            result = health_service.check_health()
+            if result.fts_synced:
+                typer.echo("✅ FTS index repaired successfully!")
+            else:
+                typer.echo("❌ FTS repair did not resolve the issue")
+        except Exception as e:
+            typer.echo(f"❌ Failed to repair FTS: {e}", err=True)
+
+    # Exit with error code if unhealthy
+    if not result.is_healthy:
+        raise typer.Exit(code=1)

--- a/src/interfaces/cli/commands/list.py
+++ b/src/interfaces/cli/commands/list.py
@@ -10,14 +10,16 @@ app = typer.Typer()
 @app.command()
 def list_observations(
     ctx: typer.Context,
-    limit: int = typer.Option(10, "--limit", "-l"),
+    limit: int = typer.Option(20, "--limit", "-l", help="Maximum number of observations to return"),
+    offset: int = typer.Option(0, "--offset", "-o", help="Number of observations to skip"),
 ) -> None:
     memory_service = ctx.obj
-    results = memory_service.get_recent(limit=limit)
+    results = memory_service.get_recent(limit=limit, offset=offset)
 
     if not results:
         typer.echo("No observations found")
         return
 
+    typer.echo(f"Showing {len(results)} observations (offset: {offset})")
     for obs in results:
         typer.echo(f"[{obs.id[:8]}] {obs.content[:80]}...")

--- a/src/interfaces/cli/commands/stats.py
+++ b/src/interfaces/cli/commands/stats.py
@@ -1,0 +1,68 @@
+"""Stats command for CLI - shows database statistics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from src.infrastructure.persistence.health_check import HealthCheckService
+from src.infrastructure.persistence.query_logger import get_query_logger
+from src.interfaces.cli.dependencies import get_health_check_service
+
+app = typer.Typer()
+
+DEFAULT_DB_PATH = Path("data/memory.db")
+
+
+def _get_health_service_from_context(ctx: typer.Context) -> HealthCheckService:
+    """Get health check service from typer context."""
+    db_path = DEFAULT_DB_PATH
+    if ctx.parent and ctx.parent.params:
+        db_path = Path(ctx.parent.params.get("db_path", DEFAULT_DB_PATH))
+
+    return get_health_check_service(db_path)
+
+
+@app.command()
+def stats(
+    ctx: typer.Context,
+    slow_queries: bool = typer.Option(False, "--slow-queries", "-s", help="Show slow query log"),
+) -> None:
+    """Show database statistics."""
+    # Get health check service for stats
+    health_service = _get_health_service_from_context(ctx)
+
+    typer.echo("📊 Database Statistics")
+    typer.echo("=" * 40)
+
+    # Get database stats
+    db_stats = health_service.get_stats()
+
+    typer.echo(f"Observations:     {db_stats['observation_count']}")
+    typer.echo(f"FTS Entries:     {db_stats['fts_count']}")
+    typer.echo(f"Database Size:   {db_stats['db_size_human']}")
+
+    # Show slow queries if requested
+    if slow_queries:
+        typer.echo("\n📝 Slow Query Log")
+        typer.echo("-" * 40)
+
+        query_logger = get_query_logger()
+        slow = query_logger.get_slow_queries()
+
+        if not slow:
+            typer.echo("No slow queries logged")
+        else:
+            typer.echo(f"Total slow queries: {len(slow)}")
+            for i, sq in enumerate(slow[:10], 1):
+                typer.echo(f"\n{i}. {sq['duration_ms']:.2f} ms")
+                typer.echo(f"   Query: {sq['query'][:60]}...")
+
+
+@app.command()
+def clear_slow_queries() -> None:
+    """Clear the slow query log."""
+    query_logger = get_query_logger()
+    query_logger.clear()
+    typer.echo("✅ Slow query log cleared")

--- a/src/interfaces/cli/dependencies.py
+++ b/src/interfaces/cli/dependencies.py
@@ -7,7 +7,9 @@ from pathlib import Path
 from src.application.services.memory_service import MemoryService
 from src.application.services.orchestration.hook_service import HookService
 from src.application.services.scheduler_service import SchedulerService
+from src.application.services.cleanup_service import CleanupService
 from src.infrastructure.persistence.container import Container, create_container
+from src.infrastructure.persistence.health_check import HealthCheckService
 
 _hook_service: HookService | None = None
 
@@ -39,3 +41,15 @@ def get_scheduler_service(db_path: Path | None = None) -> SchedulerService:
     """Get SchedulerService instance for CLI commands."""
     container = get_container(db_path)
     return container.scheduler_service()
+
+
+def get_cleanup_service(db_path: Path | None = None) -> CleanupService:
+    """Get CleanupService instance for CLI commands."""
+    container = get_container(db_path)
+    return container.cleanup_service()
+
+
+def get_health_check_service(db_path: Path | None = None) -> HealthCheckService:
+    """Get HealthCheckService instance for CLI commands."""
+    container = get_container(db_path)
+    return container.health_check_service()

--- a/src/interfaces/cli/main.py
+++ b/src/interfaces/cli/main.py
@@ -10,6 +10,9 @@ import typer
 
 from src.application.services.orchestration.events import SessionStartEvent
 from src.interfaces.cli.commands import delete, get, list, save, search
+from src.interfaces.cli.commands.cleanup import cleanup
+from src.interfaces.cli.commands.health import health
+from src.interfaces.cli.commands import stats
 from src.interfaces.cli.commands.schedule import app as schedule_app
 from src.interfaces.cli.commands.workflow import app as workflow_app
 from src.interfaces.cli.dependencies import get_hook_service, get_memory_service
@@ -27,8 +30,15 @@ app.command(name="list")(list.list_observations)
 app.command(name="get")(get.get)
 app.command(name="delete")(delete.delete)
 
+app.command(name="cleanup")(cleanup)
+
+app.command(name="health")(health)
+
 app.add_typer(schedule_app, name="schedule")
 app.add_typer(workflow_app, name="workflow")
+
+app.command(name="stats")(stats.stats)
+app.command(name="clear-slow-queries")(stats.clear_slow_queries)
 
 
 @app.callback()

--- a/tests/unit/application/services/workflow/test_goal_analyzer.py
+++ b/tests/unit/application/services/workflow/test_goal_analyzer.py
@@ -106,12 +106,3 @@ class TestGoalAnalyzer:
         error_reqs = [r for r in result if r.id == "error-handling"]
         assert len(error_reqs) == 1
         assert error_reqs[0].source == RequirementSource.EXPLICIT
-
-    def test_analyze_empty_objective(self) -> None:
-        """Test that empty objective with must-haves works."""
-        goal = Goal(objective="", must_haves=("Test",))
-        analyzer = GoalAnalyzer()
-        result = analyzer.analyze(goal)
-
-        assert len(result) == 1
-        assert result[0].id == "test"

--- a/tests/unit/application/services/workflow/test_goal_analyzer.py
+++ b/tests/unit/application/services/workflow/test_goal_analyzer.py
@@ -1,0 +1,117 @@
+"""Tests for GoalAnalyzer service."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.domain.entities.goal import Goal
+from src.domain.entities.derived_requirement import (
+    DerivedRequirement,
+    RequirementPriority,
+    RequirementSource,
+)
+from src.application.services.workflow.goal_analyzer import (
+    GoalAnalyzer,
+    GoalAnalysisError,
+    slugify,
+)
+
+
+class TestSlugify:
+    """Tests for slugify helper."""
+
+    def test_slugify_simple(self) -> None:
+        """Test simple text slugification."""
+        assert slugify("Hello World") == "hello-world"
+
+    def test_slugify_special_chars(self) -> None:
+        """Test slugification with special characters."""
+        assert slugify("Test @#$!") == "test"
+
+    def test_slugify_underscores(self) -> None:
+        """Test slugification with underscores."""
+        assert slugify("hello_world-test") == "hello-world-test"
+
+
+class TestGoalAnalyzer:
+    """Tests for GoalAnalyzer."""
+
+    def test_analyze_none_goal_returns_empty(self) -> None:
+        """Test that None goal returns empty list (backward compat)."""
+        analyzer = GoalAnalyzer()
+        result = analyzer.analyze(None)
+        assert result == []
+
+    def test_analyze_with_must_haves(self) -> None:
+        """Test analysis with explicit must-haves."""
+        goal = Goal(
+            objective="Build API",
+            must_haves=("Authentication", "CRUD"),
+        )
+        analyzer = GoalAnalyzer()
+        result = analyzer.analyze(goal)
+
+        assert len(result) >= 2
+        auth_req = next(r for r in result if r.id == "authentication")
+        assert auth_req.source == RequirementSource.EXPLICIT
+        assert auth_req.priority == RequirementPriority.MUST
+
+    def test_analyze_with_nice_to_haves(self) -> None:
+        """Test analysis with nice-to-haves."""
+        goal = Goal(
+            objective="Build API",
+            nice_to_haves=("Rate limiting",),
+        )
+        analyzer = GoalAnalyzer()
+        result = analyzer.analyze(goal)
+
+        rate_req = next(r for r in result if r.id == "rate-limiting")
+        assert rate_req.priority == RequirementPriority.NICE
+
+    def test_analyze_derives_implicit_requirements(self) -> None:
+        """Test that implicit requirements are derived from keywords."""
+        goal = Goal(
+            objective="Build a REST API with authentication",
+            must_haves=("JWT",),
+        )
+        analyzer = GoalAnalyzer()
+        result = analyzer.analyze(goal)
+
+        # Should have both explicit and derived
+        ids = [r.id for r in result]
+        assert "jwt" in ids
+        # Derived from "API"
+        assert "error-handling" in ids
+        # Derived from "authentication"
+        assert "password-hashing" in ids
+
+    def test_analyze_no_requirements_raises(self) -> None:
+        """Test that analysis with no requirements raises error."""
+        goal = Goal(objective="Do something")
+        analyzer = GoalAnalyzer()
+
+        with pytest.raises(GoalAnalysisError):
+            analyzer.analyze(goal)
+
+    def test_analyze_deduplicates_explicit_and_derived(self) -> None:
+        """Test that explicit requirements aren't duplicated as derived."""
+        goal = Goal(
+            objective="Build an API with error handling",
+            must_haves=("Error handling",),  # Explicit
+        )
+        analyzer = GoalAnalyzer()
+        result = analyzer.analyze(goal)
+
+        # Should not have duplicate error-handling
+        error_reqs = [r for r in result if r.id == "error-handling"]
+        assert len(error_reqs) == 1
+        assert error_reqs[0].source == RequirementSource.EXPLICIT
+
+    def test_analyze_empty_objective(self) -> None:
+        """Test that empty objective with must-haves works."""
+        goal = Goal(objective="", must_haves=("Test",))
+        analyzer = GoalAnalyzer()
+        result = analyzer.analyze(goal)
+
+        assert len(result) == 1
+        assert result[0].id == "test"

--- a/tests/unit/application/services/workflow/test_task_decomposer.py
+++ b/tests/unit/application/services/workflow/test_task_decomposer.py
@@ -1,0 +1,143 @@
+"""Tests for TaskDecomposer service."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.domain.entities.goal import Goal
+from src.domain.entities.derived_requirement import (
+    DerivedRequirement,
+    RequirementPriority,
+    RequirementSource,
+)
+from src.application.services.workflow.task_decomposer import (
+    TaskDecomposer,
+    CircularDependencyError,
+)
+
+
+class TestTaskDecomposer:
+    """Tests for TaskDecomposer."""
+
+    def test_decompose_basic(self) -> None:
+        """Test basic decomposition."""
+        goal = Goal(objective="Build API", must_haves=("Auth",))
+        requirements = [
+            DerivedRequirement(
+                id="auth",
+                description="Authentication",
+                source=RequirementSource.EXPLICIT,
+                priority=RequirementPriority.MUST,
+            )
+        ]
+
+        decomposer = TaskDecomposer()
+        tasks = decomposer.decompose(goal, requirements)
+
+        assert len(tasks) > 0
+        # First task should be foundation
+        assert tasks[0].slug == "project-setup"
+        # Last task should be the main goal task
+        assert tasks[-1].slug == "build-api"
+
+    def test_decompose_with_dependencies(self) -> None:
+        """Test that tasks have proper dependencies."""
+        goal = Goal(objective="Build API", must_haves=("Auth", "DB"))
+        requirements = [
+            DerivedRequirement(
+                id="auth",
+                description="Authentication",
+                source=RequirementSource.EXPLICIT,
+                priority=RequirementPriority.MUST,
+            ),
+            DerivedRequirement(
+                id="db",
+                description="Database",
+                source=RequirementSource.EXPLICIT,
+                priority=RequirementPriority.MUST,
+            ),
+        ]
+
+        decomposer = TaskDecomposer()
+        tasks = decomposer.decompose(goal, requirements)
+
+        # Find task IDs
+        task_by_slug = {t.slug: t for t in tasks}
+
+        # Core tasks should depend on setup
+        setup_id = task_by_slug["project-setup"].id
+        auth_task = task_by_slug["auth"]
+        assert setup_id in auth_task.depends_on
+
+    def test_decompose_validates_no_cycles(self) -> None:
+        """Test that decomposition validates no circular dependencies."""
+        goal = Goal(objective="Test")
+        requirements = []
+
+        # Create tasks directly to test validation
+        decomposer = TaskDecomposer()
+        tasks = [
+            type(
+                "Task",
+                (),
+                {
+                    "id": "a",
+                    "slug": "a",
+                    "description": "a",
+                    "depends_on": ("b",),
+                },
+            )(),
+            type(
+                "Task",
+                (),
+                {
+                    "id": "b",
+                    "slug": "b",
+                    "description": "b",
+                    "depends_on": ("a",),
+                },
+            )(),
+        ]
+
+        with pytest.raises(CircularDependencyError):
+            decomposer._validate_dependencies(tasks)  # type: ignore[arg-type]
+
+    def test_decompose_validates_no_self_reference(self) -> None:
+        """Test that self-referencing tasks raise error."""
+        decomposer = TaskDecomposer()
+
+        from src.application.services.workflow.state import Task
+
+        tasks = [Task(id="a", slug="a", description="a", depends_on=("a",))]
+
+        with pytest.raises(CircularDependencyError):
+            decomposer._validate_dependencies(tasks)
+
+    def test_decompose_includes_nice_to_haves(self) -> None:
+        """Test that nice-to-haves are included."""
+        goal = Goal(
+            objective="Build API",
+            must_haves=("Auth",),
+            nice_to_haves=("Docs",),
+        )
+
+        from src.application.services.workflow.goal_analyzer import GoalAnalyzer
+
+        analyzer = GoalAnalyzer()
+        requirements = analyzer.analyze(goal)
+
+        decomposer = TaskDecomposer()
+        tasks = decomposer.decompose(goal, requirements)
+
+        # Should have optional tasks
+        task_ids = [t.slug for t in tasks]
+        assert "docs" in task_ids or any("doc" in t for t in task_ids)
+
+
+class TestCircularDependencyError:
+    """Tests for CircularDependencyError exception."""
+
+    def test_error_message(self) -> None:
+        """Test error message format."""
+        error = CircularDependencyError("Test cycle")
+        assert "cycle" in str(error).lower()

--- a/tests/unit/domain/entities/test_derived_requirement.py
+++ b/tests/unit/domain/entities/test_derived_requirement.py
@@ -1,0 +1,93 @@
+"""Tests for DerivedRequirement entity."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.domain.entities.derived_requirement import (
+    DerivedRequirement,
+    RequirementPriority,
+    RequirementSource,
+)
+
+
+class TestDerivedRequirement:
+    """Tests for DerivedRequirement entity."""
+
+    def test_requirement_creation(self) -> None:
+        """Test creating a derived requirement."""
+        req = DerivedRequirement(
+            id="test-req",
+            description="Test requirement",
+            source=RequirementSource.EXPLICIT,
+            priority=RequirementPriority.MUST,
+        )
+        assert req.id == "test-req"
+        assert req.description == "Test requirement"
+        assert req.source == RequirementSource.EXPLICIT
+        assert req.priority == RequirementPriority.MUST
+
+    def test_requirement_immutable(self) -> None:
+        """Test that requirement is immutable (frozen=True)."""
+        req = DerivedRequirement(
+            id="test",
+            description="Test",
+            source=RequirementSource.EXPLICIT,
+            priority=RequirementPriority.MUST,
+        )
+        with pytest.raises(AttributeError):
+            req.id = "new-id"
+
+    def test_requirement_empty_id_raises(self) -> None:
+        """Test that empty id raises ValueError."""
+        with pytest.raises(ValueError, match="empty"):
+            DerivedRequirement(
+                id="",
+                description="Test",
+                source=RequirementSource.EXPLICIT,
+                priority=RequirementPriority.MUST,
+            )
+
+    def test_requirement_empty_description_raises(self) -> None:
+        """Test that empty description raises ValueError."""
+        with pytest.raises(ValueError, match="empty"):
+            DerivedRequirement(
+                id="test",
+                description="",
+                source=RequirementSource.EXPLICIT,
+                priority=RequirementPriority.MUST,
+            )
+
+    def test_requirement_invalid_source_raises(self) -> None:
+        """Test that invalid source raises TypeError."""
+        with pytest.raises(TypeError):
+            DerivedRequirement(
+                id="test",
+                description="Test",
+                source="invalid",  # type: ignore[arg-type]
+                priority=RequirementPriority.MUST,
+            )
+
+    def test_requirement_invalid_priority_raises(self) -> None:
+        """Test that invalid priority raises TypeError."""
+        with pytest.raises(TypeError):
+            DerivedRequirement(
+                id="test",
+                description="Test",
+                source=RequirementSource.EXPLICIT,
+                priority="invalid",  # type: ignore[arg-type]
+            )
+
+
+class TestRequirementEnums:
+    """Tests for Requirement enums."""
+
+    def test_priority_values(self) -> None:
+        """Test RequirementPriority enum values."""
+        assert RequirementPriority.MUST.value == "must"
+        assert RequirementPriority.NICE.value == "nice"
+
+    def test_source_values(self) -> None:
+        """Test RequirementSource enum values."""
+        assert RequirementSource.EXPLICIT.value == "explicit"
+        assert RequirementSource.DERIVED.value == "derived"

--- a/tests/unit/domain/entities/test_goal.py
+++ b/tests/unit/domain/entities/test_goal.py
@@ -1,0 +1,71 @@
+"""Tests for Goal entity."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.domain.entities.goal import Goal
+
+
+class TestGoal:
+    """Tests for Goal entity."""
+
+    def test_goal_creation_minimal(self) -> None:
+        """Test creating a goal with only objective."""
+        goal = Goal(objective="Build an API")
+        assert goal.objective == "Build an API"
+        assert goal.must_haves == ()
+        assert goal.nice_to_haves == ()
+        assert goal.scope_in == ()
+        assert goal.scope_out == ()
+
+    def test_goal_creation_full(self) -> None:
+        """Test creating a goal with all fields."""
+        goal = Goal(
+            objective="Build a payment API",
+            must_haves=("Stripe", "PCI compliance"),
+            nice_to_haves=("Refunds", "Analytics"),
+            scope_in=("backend",),
+            scope_out=("frontend", "mobile"),
+        )
+        assert goal.objective == "Build a payment API"
+        assert goal.must_haves == ("Stripe", "PCI compliance")
+        assert goal.nice_to_haves == ("Refunds", "Analytics")
+        assert goal.scope_in == ("backend",)
+        assert goal.scope_out == ("frontend", "mobile")
+
+    def test_goal_immutable(self) -> None:
+        """Test that goal is immutable (frozen=True)."""
+        goal = Goal(objective="Test")
+        with pytest.raises(AttributeError):
+            goal.objective = "New objective"
+
+    def test_goal_empty_objective_raises(self) -> None:
+        """Test that empty objective raises ValueError."""
+        with pytest.raises(ValueError, match="cannot be empty"):
+            Goal(objective="")
+
+    def test_goal_non_string_objective_raises(self) -> None:
+        """Test that non-string objective raises TypeError."""
+        with pytest.raises(TypeError):
+            Goal(objective=123)  # type: ignore[arg-type]
+
+    def test_goal_max_length(self) -> None:
+        """Test that very long objective raises ValueError."""
+        long_objective = "x" * 10001
+        with pytest.raises(ValueError, match="10000"):
+            Goal(objective=long_objective)
+
+    def test_goal_scope_overlap_raises(self) -> None:
+        """Test that overlapping scope_in and scope_out raises ValueError."""
+        with pytest.raises(ValueError, match="disjoint"):
+            Goal(
+                objective="Test",
+                scope_in=("backend",),
+                scope_out=("backend",),
+            )
+
+    def test_goal_collections_must_be_tuples(self) -> None:
+        """Test that collections must be tuples."""
+        with pytest.raises(TypeError):
+            Goal(objective="Test", must_haves=["not", "tuple"])  # type: ignore[arg-type]


### PR DESCRIPTION
- Add cleanup command for removing old observations with dry-run support
- Add health command for database integrity and FTS sync checks
- Add stats command for database statistics and slow query logging
- Add CleanupService for database cleanup operations
- Add HealthCheckService for database diagnostics
- Add QueryLogger for performance monitoring
- Update MemoryService.get_recent() to support offset pagination
- Update list command with offset parameter
- Register new services in DI container

Code review fixes applied:
- Move import time to module level in cleanup_service.py
- Add context-aware db_path handling in stats.py
- Remove redundant import in health.py
- Use DEFAULT_DB_PATH constant consistently across commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI: cleanup (dry-run, delete, optional VACUUM & FTS optimize)
  * CLI: health (integrity, FTS sync, counts, db size; optional FTS repair)
  * CLI: stats (DB metrics, slow-query listing) and clear-slow-queries
  * Query logging: slow-query capture and inspection

* **Refactor**
  * Listing pagination: offset support and default page size increased
  * Memory retrieval now uses repository-level pagination

* **Documentation**
  * Several new analysis/planning reports added

* **Tests**
  * New unit tests for goal analysis, task decomposition, domain entities
<!-- end of auto-generated comment: release notes by coderabbit.ai -->