### PR TITLE
fix(api): restore opencode availability under pm2

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,10 +1,12 @@
+require('dotenv').config({ path: '/Users/felipe_gonzalez/Developer/tmux_fork/.env' });
+
 module.exports = {
   apps: [
     // Fork Agent CLI (main command)
     {
       name: 'fork-agent-cli',
       script: './src/interfaces/cli/main.py',
-      interpreter: 'python3',
+      interpreter: '/Users/felipe_gonzalez/Developer/tmux_fork/.venv/bin/python',
       args: '--help',
       cwd: '/Users/felipe_gonzalez/Developer/tmux_fork',
       env: {
@@ -18,7 +20,7 @@ module.exports = {
     {
       name: 'fork-agent-api',
       script: './src/interfaces/api/main.py',
-      interpreter: 'python3',
+      interpreter: '/Users/felipe_gonzalez/Developer/tmux_fork/.venv/bin/python',
       cwd: '/Users/felipe_gonzalez/Developer/tmux_fork',
       env: {
         PYTHONUNBUFFERED: '1',
@@ -26,7 +28,9 @@ module.exports = {
         API_HOST: '0.0.0.0',
         API_PORT: '8080',
         API_DEBUG: 'false',
-        API_KEY: ''
+        API_KEY: process.env.API_KEY || '',
+        OPENCODE_BIN: '/Users/felipe_gonzalez/.opencode/bin/opencode',
+        PATH: `${process.env.PATH || ''}:/Users/felipe_gonzalez/.opencode/bin`
       },
       autorestart: true,
       watch: false,

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,4 +1,21 @@
-require('dotenv').config({ path: '/Users/felipe_gonzalez/Developer/tmux_fork/.env' });
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '.env') });
+
+const PROJECT_ROOT = __dirname;
+const VENV_PYTHON = process.env.PYTHON_INTERPRETER || path.join(PROJECT_ROOT, '.venv', 'bin', 'python');
+const OPENCODE_BIN = process.env.OPENCODE_BIN || path.join(process.env.HOME || '', '.opencode', 'bin', 'opencode');
+const OPENCODE_BIN_DIR = path.dirname(OPENCODE_BIN);
+const PROCESS_PATH = process.env.PATH || '';
+const API_ENV = {
+  PYTHONUNBUFFERED: '1',
+  PYTHONPATH: PROJECT_ROOT,
+  API_HOST: '0.0.0.0',
+  API_PORT: '8080',
+  API_DEBUG: 'false',
+  API_KEY: process.env.API_KEY || '',
+  OPENCODE_BIN,
+  PATH: `${OPENCODE_BIN_DIR}:${PROCESS_PATH}`
+};
 
 module.exports = {
   apps: [
@@ -6,12 +23,12 @@ module.exports = {
     {
       name: 'fork-agent-cli',
       script: './src/interfaces/cli/main.py',
-      interpreter: '/Users/felipe_gonzalez/Developer/tmux_fork/.venv/bin/python',
+      interpreter: VENV_PYTHON,
       args: '--help',
-      cwd: '/Users/felipe_gonzalez/Developer/tmux_fork',
+      cwd: PROJECT_ROOT,
       env: {
         PYTHONUNBUFFERED: '1',
-        PYTHONPATH: '/Users/felipe_gonzalez/Developer/tmux_fork'
+        PYTHONPATH: PROJECT_ROOT
       },
       autorestart: false,
       watch: false
@@ -20,22 +37,13 @@ module.exports = {
     {
       name: 'fork-agent-api',
       script: './src/interfaces/api/main.py',
-      interpreter: '/Users/felipe_gonzalez/Developer/tmux_fork/.venv/bin/python',
-      cwd: '/Users/felipe_gonzalez/Developer/tmux_fork',
-      env: {
-        PYTHONUNBUFFERED: '1',
-        PYTHONPATH: '/Users/felipe_gonzalez/Developer/tmux_fork',
-        API_HOST: '0.0.0.0',
-        API_PORT: '8080',
-        API_DEBUG: 'false',
-        API_KEY: process.env.API_KEY || '',
-        OPENCODE_BIN: '/Users/felipe_gonzalez/.opencode/bin/opencode',
-        PATH: `${process.env.PATH || ''}:/Users/felipe_gonzalez/.opencode/bin`
-      },
+      interpreter: VENV_PYTHON,
+      cwd: PROJECT_ROOT,
+      env: API_ENV,
       autorestart: true,
       watch: false,
       instances: 1,
       exec_mode: 'fork'
     }
   ]
-}
+};

--- a/src/infrastructure/agent_backends/__init__.py
+++ b/src/infrastructure/agent_backends/__init__.py
@@ -23,6 +23,14 @@ _BACKENDS: dict[str, type[Any]] = {
 _backend_instances: dict[str, AgentBackend] = {}
 
 
+def clear_backend_cache() -> None:
+    """Clear backend instance cache.
+
+    Useful for tests that need registry isolation.
+    """
+    _backend_instances.clear()
+
+
 def get_backend(name: str) -> AgentBackend | None:
     """Get a backend instance by name.
 
@@ -85,6 +93,7 @@ def list_all_backends() -> list[str]:
 __all__ = [
     "OpencodeBackend",
     "PiBackend",
+    "clear_backend_cache",
     "get_backend",
     "get_available_backends",
     "get_default_backend",

--- a/src/infrastructure/agent_backends/__init__.py
+++ b/src/infrastructure/agent_backends/__init__.py
@@ -1,0 +1,92 @@
+"""Agent backend implementations and registry."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, cast
+
+from .opencode_backend import OpencodeBackend
+from .pi_backend import PiBackend
+
+if TYPE_CHECKING:
+    from src.domain.ports.agent_backend import AgentBackend
+
+logger = logging.getLogger(__name__)
+
+# Available backend implementations (ordered by preference)
+_BACKENDS: dict[str, type[Any]] = {
+    "opencode": OpencodeBackend,
+    "pi": PiBackend,
+}
+
+# Cache for backend instances
+_backend_instances: dict[str, AgentBackend] = {}
+
+
+def get_backend(name: str) -> AgentBackend | None:
+    """Get a backend instance by name.
+
+    Args:
+        name: Backend identifier ('opencode' or 'pi').
+
+    Returns:
+        Backend instance or None if not found.
+    """
+    if name in _backend_instances:
+        return _backend_instances[name]
+
+    backend_class = _BACKENDS.get(name)
+    if backend_class is None:
+        logger.warning(f"Unknown backend: {name}")
+        return None
+
+    instance = cast("AgentBackend", backend_class())
+    _backend_instances[name] = instance
+    return instance
+
+
+def get_available_backends() -> list[AgentBackend]:
+    """Get list of all available (installed) backends.
+
+    Returns:
+        List of backend instances that are installed and ready.
+    """
+    return [
+        backend
+        for name in _BACKENDS
+        if (backend := get_backend(name)) and backend.is_available()
+    ]
+
+
+def get_default_backend() -> AgentBackend | None:
+    """Get the default available backend.
+
+    Iterates through backends in definition order (opencode first).
+
+    Returns:
+        Default backend instance or None if none available.
+    """
+    for name in _BACKENDS:
+        backend = get_backend(name)
+        if backend and backend.is_available():
+            return backend
+    return None
+
+
+def list_all_backends() -> list[str]:
+    """List all registered backend names.
+
+    Returns:
+        List of backend identifiers.
+    """
+    return list(_BACKENDS.keys())
+
+
+__all__ = [
+    "OpencodeBackend",
+    "PiBackend",
+    "get_backend",
+    "get_available_backends",
+    "get_default_backend",
+    "list_all_backends",
+]

--- a/src/infrastructure/agent_backends/opencode_backend.py
+++ b/src/infrastructure/agent_backends/opencode_backend.py
@@ -1,0 +1,104 @@
+"""OpenCode CLI backend implementation."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+from pathlib import Path
+
+
+class OpencodeBackend:
+    """Backend for opencode CLI coding agent.
+
+    Default strategy requested by user:
+    - Primary model: opencode/minimax-m2.5-free
+    - Fallback model: opencode/minimax-m2.5
+
+    A fallback retry is executed in a POSIX shell (`bash -lc`) so behavior is
+    deterministic even when the tmux session default shell is fish.
+
+    Binary resolution order is explicit and suitable for non-interactive
+    processes such as pm2-managed services:
+    1. `OPENCODE_BIN` env override
+    2. `PATH` lookup via `shutil.which("opencode")`
+    3. Known user-local install path: `~/.opencode/bin/opencode`
+    """
+
+    name: str = "opencode"
+    display_name: str = "OpenCode CLI"
+
+    @staticmethod
+    def _is_executable(path: str) -> bool:
+        """Return whether a path exists and is executable."""
+        return Path(path).is_file() and os.access(path, os.X_OK)
+
+    def resolve_executable(self) -> str | None:
+        """Resolve the OpenCode executable path.
+
+        Returns:
+            Absolute executable path when found, otherwise None.
+        """
+        candidates: list[str] = []
+
+        env_override = os.getenv("OPENCODE_BIN", "").strip()
+        if env_override:
+            candidates.append(env_override)
+
+        which_result = shutil.which("opencode")
+        if which_result:
+            candidates.append(which_result)
+
+        candidates.append(str(Path.home() / ".opencode" / "bin" / "opencode"))
+
+        seen: set[str] = set()
+        for candidate in candidates:
+            if candidate in seen:
+                continue
+            seen.add(candidate)
+            if self._is_executable(candidate):
+                return candidate
+
+        return None
+
+    def is_available(self) -> bool:
+        """Check if opencode CLI is installed."""
+        return self.resolve_executable() is not None
+
+    def get_launch_command(self, task: str, model: str) -> str:
+        """Build opencode launch command with model fallback.
+
+        Args:
+            task: The task/prompt for the agent.
+            model: Primary model identifier.
+
+        Returns:
+            Shell command string with proper escaping.
+        """
+        executable = self.resolve_executable() or "opencode"
+        quoted_executable = shlex.quote(executable)
+        primary_model = model
+        fallback_model = os.getenv("OPENCODE_FALLBACK_MODEL", "opencode/minimax-m2.5")
+
+        primary_cmd = (
+            f"{quoted_executable} run -m {shlex.quote(primary_model)} {shlex.quote(task)}"
+        )
+
+        if fallback_model == primary_model:
+            return primary_cmd
+
+        fallback_cmd = (
+            f"{quoted_executable} run -m {shlex.quote(fallback_model)} {shlex.quote(task)}"
+        )
+        script = (
+            f"{primary_cmd}; rc=$?; "
+            f"if [ $rc -ne 0 ]; then "
+            f"echo '[fork-agent] primary model failed, retrying fallback model: {fallback_model}' >&2; "
+            f"{fallback_cmd}; "
+            "fi"
+        )
+        return f"bash -lc {shlex.quote(script)}"
+
+    def get_default_model(self) -> str:
+        """Get default model for opencode (override with env if needed)."""
+        return os.getenv("OPENCODE_DEFAULT_MODEL", "opencode/minimax-m2.5-free")

--- a/src/infrastructure/agent_backends/opencode_backend.py
+++ b/src/infrastructure/agent_backends/opencode_backend.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import shlex
 import shutil
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 class OpencodeBackend:
@@ -75,10 +78,19 @@ class OpencodeBackend:
         Returns:
             Shell command string with proper escaping.
         """
-        executable = self.resolve_executable() or "opencode"
+        executable = self.resolve_executable()
+        if executable is None:
+            logger.warning(
+                "opencode executable not resolved; falling back to PATH lookup for launch command"
+            )
+            executable = "opencode"
+
         quoted_executable = shlex.quote(executable)
         primary_model = model
         fallback_model = os.getenv("OPENCODE_FALLBACK_MODEL", "opencode/minimax-m2.5")
+        fallback_message = shlex.quote(
+            f"[fork-agent] primary model failed, retrying fallback model: {fallback_model}"
+        )
 
         primary_cmd = (
             f"{quoted_executable} run -m {shlex.quote(primary_model)} {shlex.quote(task)}"
@@ -93,7 +105,7 @@ class OpencodeBackend:
         script = (
             f"{primary_cmd}; rc=$?; "
             f"if [ $rc -ne 0 ]; then "
-            f"echo '[fork-agent] primary model failed, retrying fallback model: {fallback_model}' >&2; "
+            f"echo {fallback_message} >&2; "
             f"{fallback_cmd}; "
             "fi"
         )

--- a/src/infrastructure/agent_backends/pi_backend.py
+++ b/src/infrastructure/agent_backends/pi_backend.py
@@ -1,0 +1,48 @@
+"""pi.dev coding agent backend implementation."""
+
+from __future__ import annotations
+
+import shlex
+import shutil
+
+
+class PiBackend:
+    """Backend for pi.dev coding agent.
+
+    Reference: https://mariozechner.at/posts/2025-11-30-pi-coding-agent/
+
+    pi is a coding agent that focuses on deep code understanding
+    and iterative development. It runs tasks via: pi '{task}'
+    """
+
+    name: str = "pi"
+    display_name: str = "pi.dev Agent"
+
+    def is_available(self) -> bool:
+        """Check if pi CLI is installed."""
+        return shutil.which("pi") is not None
+
+    def get_launch_command(self, task: str, model: str) -> str:
+        """Build pi launch command.
+
+        Supports provider-qualified model IDs like:
+        `nvidia-nim/minimaxai/minimax-m2.5`.
+
+        For reliability, pass both `--provider` and `--model` when provider
+        prefix is present.
+        """
+        base = "pi"
+        if model and model != "pi/default":
+            if "/" in model:
+                provider, model_id = model.split("/", 1)
+                base += (
+                    f" --provider {shlex.quote(provider)}"
+                    f" --model {shlex.quote(model_id)}"
+                )
+            else:
+                base += f" --model {shlex.quote(model)}"
+        return f"{base} {shlex.quote(task)}"
+
+    def get_default_model(self) -> str:
+        """Get deterministic default model for pi backend sessions."""
+        return "nvidia-nim/minimaxai/minimax-m2.5"

--- a/tests/unit/infrastructure/agent_backends/test_backends.py
+++ b/tests/unit/infrastructure/agent_backends/test_backends.py
@@ -1,0 +1,212 @@
+"""Unit tests for agent backends."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from src.infrastructure.agent_backends import (
+    OpencodeBackend,
+    PiBackend,
+    get_available_backends,
+    get_backend,
+    get_default_backend,
+    list_all_backends,
+)
+
+
+class TestOpencodeBackend:
+    """Tests for OpencodeBackend."""
+
+    def test_name_property(self) -> None:
+        backend = OpencodeBackend()
+        assert backend.name == "opencode"
+
+    def test_display_name_property(self) -> None:
+        backend = OpencodeBackend()
+        assert backend.display_name == "OpenCode CLI"
+
+    def test_is_available_returns_true_when_installed_in_path(self) -> None:
+        backend = OpencodeBackend()
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch("shutil.which", return_value="/usr/bin/opencode"),
+            patch.object(backend, "_is_executable", return_value=True),
+        ):
+            assert backend.is_available() is True
+
+    def test_is_available_returns_true_when_env_override_is_executable(self) -> None:
+        backend = OpencodeBackend()
+        with (
+            patch.dict("os.environ", {"OPENCODE_BIN": "/custom/opencode"}, clear=True),
+            patch("shutil.which", return_value=None),
+            patch.object(
+                backend,
+                "_is_executable",
+                side_effect=lambda path: path == "/custom/opencode",
+            ),
+        ):
+            assert backend.is_available() is True
+
+    def test_is_available_returns_true_when_home_fallback_is_executable(self) -> None:
+        backend = OpencodeBackend()
+        fallback = "/Users/test/.opencode/bin/opencode"
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch("shutil.which", return_value=None),
+            patch("pathlib.Path.home", return_value=Path("/Users/test")),
+            patch.object(backend, "_is_executable", side_effect=lambda path: path == fallback),
+        ):
+            assert backend.is_available() is True
+
+    def test_is_available_returns_false_when_not_installed(self) -> None:
+        backend = OpencodeBackend()
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch("shutil.which", return_value=None),
+            patch.object(backend, "_is_executable", return_value=False),
+        ):
+            assert backend.is_available() is False
+
+    def test_get_launch_command_basic(self) -> None:
+        backend = OpencodeBackend()
+        with patch.object(backend, "resolve_executable", return_value="/custom/opencode"):
+            cmd = backend.get_launch_command("test task", "opencode/minimax-m2.5-free")
+        assert "bash -lc" in cmd
+        assert "/custom/opencode run -m" in cmd
+        assert "minimax-m2.5" in cmd
+
+    def test_get_launch_command_uses_resolved_binary_for_opencode_go_models(self) -> None:
+        backend = OpencodeBackend()
+        with patch.object(backend, "resolve_executable", return_value="/custom/opencode"):
+            cmd = backend.get_launch_command("test task", "opencode-go/minimax-m2.5")
+        assert "/custom/opencode run -m opencode-go/minimax-m2.5" in cmd
+
+    def test_get_launch_command_escapes_special_chars(self) -> None:
+        backend = OpencodeBackend()
+        # Test various shell metacharacters
+        cmd = backend.get_launch_command("it's a test", "gpt-4")
+        # shlex.quote should properly escape
+        assert "opencode run -m" in cmd
+
+    def test_get_launch_command_prevents_injection(self) -> None:
+        backend = OpencodeBackend()
+        # Test command injection attempts are neutralized
+        cmd = backend.get_launch_command("$(malicious)", "gpt-4; rm -rf /")
+        # shlex.quote should escape these so they're not executed
+        assert "$(malicious)" in cmd  # Present but escaped
+        assert "rm -rf" in cmd  # Present but escaped as part of model
+
+    def test_get_default_model(self) -> None:
+        backend = OpencodeBackend()
+        assert backend.get_default_model() == "opencode/minimax-m2.5-free"
+
+
+class TestPiBackend:
+    """Tests for PiBackend."""
+
+    def test_name_property(self) -> None:
+        backend = PiBackend()
+        assert backend.name == "pi"
+
+    def test_display_name_property(self) -> None:
+        backend = PiBackend()
+        assert backend.display_name == "pi.dev Agent"
+
+    def test_is_available_returns_true_when_installed(self) -> None:
+        backend = PiBackend()
+        with patch("shutil.which", return_value="/usr/bin/pi"):
+            assert backend.is_available() is True
+
+    def test_is_available_returns_false_when_not_installed(self) -> None:
+        backend = PiBackend()
+        with patch("shutil.which", return_value=None):
+            assert backend.is_available() is False
+
+    def test_get_launch_command_basic(self) -> None:
+        backend = PiBackend()
+        cmd = backend.get_launch_command("test task", "ignored-model")
+        assert cmd.startswith("pi ")
+        assert "test task" in cmd
+        assert "--model ignored-model" in cmd
+
+    def test_get_launch_command_escapes_special_chars(self) -> None:
+        backend = PiBackend()
+        cmd = backend.get_launch_command("it's a test", "model")
+        # shlex.quote should properly escape
+        assert "pi " in cmd
+
+    def test_get_launch_command_prevents_injection(self) -> None:
+        backend = PiBackend()
+        # Test command injection attempts are neutralized
+        cmd = backend.get_launch_command("$(malicious)", "model")
+        # shlex.quote should escape so they're not executed
+        assert "$(malicious)" in cmd  # Present but escaped
+
+    def test_get_default_model(self) -> None:
+        backend = PiBackend()
+        assert backend.get_default_model() == "nvidia-nim/minimaxai/minimax-m2.5"
+
+
+class TestBackendRegistry:
+    """Tests for backend registry functions."""
+
+    def test_list_all_backends(self) -> None:
+        backends = list_all_backends()
+        assert "opencode" in backends
+        assert "pi" in backends
+
+    def test_get_backend_returns_opencode(self) -> None:
+        backend = get_backend("opencode")
+        assert backend is not None
+        assert isinstance(backend, OpencodeBackend)
+
+    def test_get_backend_returns_pi(self) -> None:
+        backend = get_backend("pi")
+        assert backend is not None
+        assert isinstance(backend, PiBackend)
+
+    def test_get_backend_returns_none_for_unknown(self) -> None:
+        backend = get_backend("unknown")
+        assert backend is None
+
+    def test_get_backend_caches_instances(self) -> None:
+        backend1 = get_backend("opencode")
+        backend2 = get_backend("opencode")
+        assert backend1 is backend2
+
+    def test_get_available_backends_filters_by_availability(self) -> None:
+        with (
+            patch.object(OpencodeBackend, "is_available", return_value=True),
+            patch.object(PiBackend, "is_available", return_value=False),
+        ):
+            available = get_available_backends()
+            names = [b.name for b in available]
+            assert "opencode" in names
+            assert "pi" not in names
+
+    def test_get_default_backend_prefers_opencode(self) -> None:
+        with (
+            patch.object(OpencodeBackend, "is_available", return_value=True),
+            patch.object(PiBackend, "is_available", return_value=True),
+        ):
+            default = get_default_backend()
+            assert default is not None
+            assert default.name == "opencode"
+
+    def test_get_default_backend_falls_back_to_pi(self) -> None:
+        with (
+            patch.object(OpencodeBackend, "is_available", return_value=False),
+            patch.object(PiBackend, "is_available", return_value=True),
+        ):
+            default = get_default_backend()
+            assert default is not None
+            assert default.name == "pi"
+
+    def test_get_default_backend_returns_none_when_none_available(self) -> None:
+        with (
+            patch.object(OpencodeBackend, "is_available", return_value=False),
+            patch.object(PiBackend, "is_available", return_value=False),
+        ):
+            default = get_default_backend()
+            assert default is None

--- a/tests/unit/infrastructure/agent_backends/test_backends.py
+++ b/tests/unit/infrastructure/agent_backends/test_backends.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 from src.infrastructure.agent_backends import (
     OpencodeBackend,
     PiBackend,
+    clear_backend_cache,
     get_available_backends,
     get_backend,
     get_default_backend,
@@ -30,7 +31,10 @@ class TestOpencodeBackend:
         backend = OpencodeBackend()
         with (
             patch.dict("os.environ", {}, clear=True),
-            patch("shutil.which", return_value="/usr/bin/opencode"),
+            patch(
+                "src.infrastructure.agent_backends.opencode_backend.shutil.which",
+                return_value="/usr/bin/opencode",
+            ),
             patch.object(backend, "_is_executable", return_value=True),
         ):
             assert backend.is_available() is True
@@ -39,7 +43,7 @@ class TestOpencodeBackend:
         backend = OpencodeBackend()
         with (
             patch.dict("os.environ", {"OPENCODE_BIN": "/custom/opencode"}, clear=True),
-            patch("shutil.which", return_value=None),
+            patch("src.infrastructure.agent_backends.opencode_backend.shutil.which", return_value=None),
             patch.object(
                 backend,
                 "_is_executable",
@@ -53,7 +57,7 @@ class TestOpencodeBackend:
         fallback = "/Users/test/.opencode/bin/opencode"
         with (
             patch.dict("os.environ", {}, clear=True),
-            patch("shutil.which", return_value=None),
+            patch("src.infrastructure.agent_backends.opencode_backend.shutil.which", return_value=None),
             patch("pathlib.Path.home", return_value=Path("/Users/test")),
             patch.object(backend, "_is_executable", side_effect=lambda path: path == fallback),
         ):
@@ -63,7 +67,7 @@ class TestOpencodeBackend:
         backend = OpencodeBackend()
         with (
             patch.dict("os.environ", {}, clear=True),
-            patch("shutil.which", return_value=None),
+            patch("src.infrastructure.agent_backends.opencode_backend.shutil.which", return_value=None),
             patch.object(backend, "_is_executable", return_value=False),
         ):
             assert backend.is_available() is False
@@ -82,6 +86,16 @@ class TestOpencodeBackend:
             cmd = backend.get_launch_command("test task", "opencode-go/minimax-m2.5")
         assert "/custom/opencode run -m opencode-go/minimax-m2.5" in cmd
 
+    def test_get_launch_command_logs_warning_when_resolution_fails(self) -> None:
+        backend = OpencodeBackend()
+        with (
+            patch.object(backend, "resolve_executable", return_value=None),
+            patch("src.infrastructure.agent_backends.opencode_backend.logger.warning") as warning,
+        ):
+            cmd = backend.get_launch_command("test task", "opencode/minimax-m2.5-free")
+        warning.assert_called_once()
+        assert "opencode run -m" in cmd
+
     def test_get_launch_command_escapes_special_chars(self) -> None:
         backend = OpencodeBackend()
         # Test various shell metacharacters
@@ -98,8 +112,9 @@ class TestOpencodeBackend:
         assert "rm -rf" in cmd  # Present but escaped as part of model
 
     def test_get_default_model(self) -> None:
-        backend = OpencodeBackend()
-        assert backend.get_default_model() == "opencode/minimax-m2.5-free"
+        with patch.dict("os.environ", {}, clear=True):
+            backend = OpencodeBackend()
+            assert backend.get_default_model() == "opencode/minimax-m2.5-free"
 
 
 class TestPiBackend:
@@ -115,12 +130,12 @@ class TestPiBackend:
 
     def test_is_available_returns_true_when_installed(self) -> None:
         backend = PiBackend()
-        with patch("shutil.which", return_value="/usr/bin/pi"):
+        with patch("src.infrastructure.agent_backends.pi_backend.shutil.which", return_value="/usr/bin/pi"):
             assert backend.is_available() is True
 
     def test_is_available_returns_false_when_not_installed(self) -> None:
         backend = PiBackend()
-        with patch("shutil.which", return_value=None):
+        with patch("src.infrastructure.agent_backends.pi_backend.shutil.which", return_value=None):
             assert backend.is_available() is False
 
     def test_get_launch_command_basic(self) -> None:
@@ -152,30 +167,36 @@ class TestBackendRegistry:
     """Tests for backend registry functions."""
 
     def test_list_all_backends(self) -> None:
+        clear_backend_cache()
         backends = list_all_backends()
         assert "opencode" in backends
         assert "pi" in backends
 
     def test_get_backend_returns_opencode(self) -> None:
+        clear_backend_cache()
         backend = get_backend("opencode")
         assert backend is not None
         assert isinstance(backend, OpencodeBackend)
 
     def test_get_backend_returns_pi(self) -> None:
+        clear_backend_cache()
         backend = get_backend("pi")
         assert backend is not None
         assert isinstance(backend, PiBackend)
 
     def test_get_backend_returns_none_for_unknown(self) -> None:
+        clear_backend_cache()
         backend = get_backend("unknown")
         assert backend is None
 
     def test_get_backend_caches_instances(self) -> None:
+        clear_backend_cache()
         backend1 = get_backend("opencode")
         backend2 = get_backend("opencode")
         assert backend1 is backend2
 
     def test_get_available_backends_filters_by_availability(self) -> None:
+        clear_backend_cache()
         with (
             patch.object(OpencodeBackend, "is_available", return_value=True),
             patch.object(PiBackend, "is_available", return_value=False),
@@ -186,6 +207,7 @@ class TestBackendRegistry:
             assert "pi" not in names
 
     def test_get_default_backend_prefers_opencode(self) -> None:
+        clear_backend_cache()
         with (
             patch.object(OpencodeBackend, "is_available", return_value=True),
             patch.object(PiBackend, "is_available", return_value=True),
@@ -195,6 +217,7 @@ class TestBackendRegistry:
             assert default.name == "opencode"
 
     def test_get_default_backend_falls_back_to_pi(self) -> None:
+        clear_backend_cache()
         with (
             patch.object(OpencodeBackend, "is_available", return_value=False),
             patch.object(PiBackend, "is_available", return_value=True),
@@ -204,6 +227,7 @@ class TestBackendRegistry:
             assert default.name == "pi"
 
     def test_get_default_backend_returns_none_when_none_available(self) -> None:
+        clear_backend_cache()
         with (
             patch.object(OpencodeBackend, "is_available", return_value=False),
             patch.object(PiBackend, "is_available", return_value=False),


### PR DESCRIPTION
## Summary
- make `OpencodeBackend` resolve the binary explicitly for non-interactive `pm2` processes
- reuse the resolved executable in launch commands so availability and execution stay consistent
- add focused backend tests and explicit PM2 env wiring for `OPENCODE_BIN` / `PATH`

## Validation
- [x] `uv run pytest tests/unit/infrastructure/agent_backends/test_backends.py -q`
- [x] `uv run ruff check src/infrastructure/agent_backends/opencode_backend.py tests/unit/infrastructure/agent_backends/test_backends.py`
- [x] `uv run mypy src/infrastructure/agent_backends/opencode_backend.py`
- [x] `GET /api/v1/health` shows `opencode` and `pi` available after PM2 restart
- [x] `POST /api/v1/agents/sessions` accepts `agent_type=opencode` with `model=opencode-go/minimax-m2.5`

## Risks / follow-ups
- `ecosystem.config.cjs` still contains machine-specific absolute paths and could be made more portable in a follow-up.
- Reviewctl static gates were normalized to the isolated backend scope for branch review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for multiple AI agent backends (OpenCode CLI and pi.dev) with automatic availability detection and selectable defaults.
  * Backends build safe launch commands with model selection and fallback behavior.

* **Chores**
  * Updated deployment configuration to initialize environment variables and use virtualenv-aware interpreters and paths.

* **Tests**
  * Added comprehensive unit tests covering backend discovery, command construction, defaults, and registry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->