### PR TITLE
chore: add .trifecta/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ skill.md
 another/
 custom/
 
+.trifecta/

--- a/.gitignore
+++ b/.gitignore
@@ -124,9 +124,9 @@ memory.db
 TRIFECTA_USAGE.md
 readme_tf.md
 skill.md
+.trifecta/
 
 # Test DBs outside data/
 another/
 custom/
 
-.trifecta/


### PR DESCRIPTION
## What

Adds  to .

## Why

 is a local runtime cache directory generated by Trifecta v2 during context injection and skill resolution. It contains:

- AST cache (SQLite DB, ~80KB)
- Context packs (JSONL chunks)
- Aliases and anchors (YAML)

These are machine-generated, project-specific, and should not be tracked in version control.

## Test plan

- [x] On branch chore/gitignore-trifecta-cache
Your branch is up to date with 'origin/chore/gitignore-trifecta-cache'.

nothing to commit, working tree clean shows no untracked  directory
- [x] Existing tracked files unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to ignore an additional local/state artifact directory, reducing noise from environment-specific files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->