### PR TITLE
fix: address Copilot/CodeRabbit/Codex review findings

### DIFF
--- a/src/infrastructure/persistence/repositories/telemetry_repository.py
+++ b/src/infrastructure/persistence/repositories/telemetry_repository.py
@@ -275,7 +275,7 @@ class TelemetryRepositoryImpl(TelemetryRepository):
         self,
         metric_name: str,
         labels: dict[str, str],
-        _bucket_duration: int,
+        bucket_duration: int,  # noqa: ARG002 — required by Protocol, not used in current query
         start_time: int,
         end_time: int,
     ) -> list[MetricBucket]:

--- a/src/interfaces/mcp/tools/_shared.py
+++ b/src/interfaces/mcp/tools/_shared.py
@@ -42,7 +42,8 @@ def _detect_project() -> str:
     """
     import os
 
-    return os.path.basename(os.getcwd())
+    name = os.path.basename(os.getcwd())
+    return name or "default"
 
 
 def _resolve_project(project: str | None) -> str:
@@ -110,7 +111,10 @@ def init_service(db_path: str | None = None) -> None:
     global _custom_db_path
     from pathlib import Path
 
-    _custom_db_path = Path(db_path) if db_path else None
+    new_path = Path(db_path) if db_path else None
+    if new_path != _custom_db_path:
+        _singletons.clear()
+    _custom_db_path = new_path
     _get_memory_service()
     _get_session_service()
     _get_health_service()

--- a/src/interfaces/mcp/tools/memory.py
+++ b/src/interfaces/mcp/tools/memory.py
@@ -43,8 +43,9 @@ def _cap_json_response(
     if estimate_tokens(raw_json) > effective_max:
         serialized = data if isinstance(data, list) else [data]
         serialized = cap_response(serialized, effective_max)
-        if isinstance(data, dict) and serialized:
-            return json.dumps(serialized[0])
+        if isinstance(data, dict):
+            # Preserve object shape — return first item or empty dict, never a list
+            return json.dumps(serialized[0] if serialized else {})
         return json.dumps(serialized)
     return raw_json
 


### PR DESCRIPTION
## Summary

Fixes 4 issues found by bot reviews on PR #31 (and pre-existing issues visible in the diff).

### Changes

1. **_shared.py**: init_service() clears _singletons when db_path changes (Codex P1, CodeRabbit major)
2. **_shared.py**: _detect_project() returns "default" for empty basename instead of empty string (Copilot)
3. **memory.py**: _cap_json_response preserves dict shape when cap returns empty — was returning "[]" instead of "{}" for dict inputs (Codex P2, Copilot)
4. **telemetry_repository.py**: aggregate_metric param restored to bucket_duration to match Protocol + noqa for unused param (Copilot, CodeRabbit major)

### Already correct on main (5 issues bots flagged)

- telemetry_service.py: already uses bucket_duration (no underscore)
- observation_repository.py: Protocol already has project param
- test_tools.py: no hardcoded project="tmux_fork" on main
- conftest.py / test_fake_clock.py: don't exist on main (autoresearch branch artifacts)
- autoresearch.sh/jsonl/md: session artifacts, not code

### Verification

- 1652 tests pass
- ruff clean, mypy clean
