### PR TITLE
perf(cli): lazy imports + fix bot review findings (supersedes #31 #32)

### DIFF
--- a/src/infrastructure/persistence/repositories/telemetry_repository.py
+++ b/src/infrastructure/persistence/repositories/telemetry_repository.py
@@ -275,7 +275,7 @@ class TelemetryRepositoryImpl(TelemetryRepository):
         self,
         metric_name: str,
         labels: dict[str, str],
-        _bucket_duration: int,
+        bucket_duration: int,  # noqa: ARG002 — required by Protocol, not used in current query
         start_time: int,
         end_time: int,
     ) -> list[MetricBucket]:

--- a/src/interfaces/cli/__init__.py
+++ b/src/interfaces/cli/__init__.py
@@ -1,13 +1,28 @@
 """CLI interfaces."""
 
-from src.interfaces.cli.fork import (
-    ForkTerminalFn,
-    create_fork_cli,
-    run_cli,
-)
+from typing import Any
+
+# Lazy imports via PEP 562 to avoid loading fork.py (82ms) at module import time.
+# fork.py pulls in agent_manager, terminal entities, message commands, etc.
+_LAZY_IMPORTS = {
+    "ForkTerminalFn": "src.interfaces.cli.fork",
+    "create_fork_cli": "src.interfaces.cli.fork",
+    "run_cli": "src.interfaces.cli.fork",
+}
 
 __all__ = [
     "create_fork_cli",
     "run_cli",
     "ForkTerminalFn",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    if name in _LAZY_IMPORTS:
+        mod = __import__(_LAZY_IMPORTS[name], fromlist=[name])
+        return getattr(mod, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return list(globals()) + list(_LAZY_IMPORTS)

--- a/src/interfaces/cli/main.py
+++ b/src/interfaces/cli/main.py
@@ -1,50 +1,19 @@
-"""Memory CLI - Main entry point."""
+"""Memory CLI - Main entry point.
+
+Uses deferred command registration to reduce cold-start time. Command modules
+and heavy infrastructure imports are loaded on first CLI invocation, not at
+import time. This saves ~90ms of cold-start overhead.
+"""
 
 from __future__ import annotations
 
 import logging
-import uuid
+import types
 from pathlib import Path
+from typing import Any
 
 import click
 import typer
-
-from src.application.services.orchestration.events import SessionStartEvent
-from src.infrastructure.persistence.container import get_default_db_path
-from src.interfaces.cli.commands import (
-    context,
-    delete,
-    diff,
-    get,
-    list,
-    mcp,
-    retrieve,
-    save,
-    search,
-    stats,
-    tui,
-    update,
-)
-from src.interfaces.cli.commands.cleanup import cleanup
-from src.interfaces.cli.commands.compact import app as compact_app
-from src.interfaces.cli.commands.export import app as export_app
-from src.interfaces.cli.commands.health import health
-from src.interfaces.cli.commands.import_ import app as import_app
-from src.interfaces.cli.commands.message import app as message_app
-from src.interfaces.cli.commands.project import app as project_app
-from src.interfaces.cli.commands.prompt import app as prompt_app
-from src.interfaces.cli.commands.query import app as query_app
-from src.interfaces.cli.commands.schedule import app as schedule_app
-from src.interfaces.cli.commands.session import app as session_app
-from src.interfaces.cli.commands.sync import app as sync_app
-from src.interfaces.cli.commands.telemetry import app as telemetry_app
-from src.interfaces.cli.commands.workflow import app as workflow_app
-from src.interfaces.cli.dependencies import (
-    get_hook_service,
-    get_memory_service,
-    get_telemetry_service,
-)
-from src.interfaces.cli.workspace_commands import workspace as workspace_click_group
 
 logger = logging.getLogger(__name__)
 
@@ -53,79 +22,194 @@ app = typer.Typer(
     help="Manage agent memory observations",
 )
 
-app.command(name="save")(save.save)
-app.command(
-    name="search", help="Full-text search using FTS5. Returns observations ranked by relevance."
-)(search.search)
-app.command(name="retrieve")(retrieve.retrieve)
-app.command(name="list", help="List recent observations in reverse chronological order.")(
-    list.list_observations
+# Module-level lazy imports via __getattr__ (PEP 562).
+# These exist for backward compatibility with tests that patch this module.
+# Frozen via MappingProxyType to prevent runtime mutation (defence in depth).
+_LAZY_IMPORTS = types.MappingProxyType(
+    {
+        "get_memory_service": "src.infrastructure.persistence.container",
+        "get_telemetry_service": "src.interfaces.cli.dependencies",
+        "get_hook_service": "src.interfaces.cli.dependencies",
+    }
 )
-app.command(name="get", help="Get a single observation by ID (accepts 8+ char prefix).")(get.get)
-app.command(name="delete")(delete.delete)
-app.command(name="diff")(diff.diff)
-
-app.command(name="update")(update.update)
-app.command(name="context")(context.context)
-
-app.command(name="cleanup")(cleanup)
-
-app.command(name="health")(health)
-
-app.add_typer(schedule_app, name="schedule")
-app.add_typer(telemetry_app, name="telemetry")
-app.add_typer(query_app, name="query")
-app.add_typer(session_app, name="session")
-app.add_typer(sync_app, name="sync")
-app.add_typer(compact_app, name="compact")
-app.add_typer(mcp.app, name="mcp")
-app.add_typer(project_app, name="project")
-app.add_typer(prompt_app, name="prompt")
-app.add_typer(export_app, name="export")
-app.add_typer(import_app, name="import")
-app.add_typer(workflow_app, name="workflow")
-app.add_typer(message_app, name="message")
 
 
-app.command(name="stats")(stats.stats)
-app.command(name="clear-slow-queries")(stats.clear_slow_queries)
-app.command(name="tui")(tui.launch)
+def __getattr__(name: str) -> Any:
+    """Lazy module-level attribute access for test patching compatibility."""
+    if name in _LAZY_IMPORTS:
+        mod = __import__(_LAZY_IMPORTS[name], fromlist=[name])
+        return getattr(mod, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Advertise lazy exports for dir() and IDE autocomplete."""
+    return list(globals()) + list(_LAZY_IMPORTS)
+
+
+_commands_registered = False
+
+
+def _register_commands() -> None:
+    """Register all commands. Called once on first CLI invocation.
+
+    Guards against double registration to support both the _LazyCLI proxy
+    and direct test invocation (main._register_commands()).
+    """
+    global _commands_registered
+    if _commands_registered:
+        return
+
+    from src.interfaces.cli.commands import (
+        context,
+        delete,
+        diff,
+        get,
+        list,
+        mcp,
+        retrieve,
+        save,
+        search,
+        stats,
+        tui,
+        update,
+    )
+    from src.interfaces.cli.commands.cleanup import cleanup
+    from src.interfaces.cli.commands.compact import app as compact_app
+    from src.interfaces.cli.commands.export import app as export_app
+    from src.interfaces.cli.commands.health import health
+    from src.interfaces.cli.commands.import_ import app as import_app
+    from src.interfaces.cli.commands.message import app as message_app
+    from src.interfaces.cli.commands.project import app as project_app
+    from src.interfaces.cli.commands.prompt import app as prompt_app
+    from src.interfaces.cli.commands.query import app as query_app
+    from src.interfaces.cli.commands.schedule import app as schedule_app
+    from src.interfaces.cli.commands.session import app as session_app
+    from src.interfaces.cli.commands.sync import app as sync_app
+    from src.interfaces.cli.commands.telemetry import app as telemetry_app
+    from src.interfaces.cli.commands.workflow import app as workflow_app
+
+    app.command(name="save")(save.save)
+    app.command(
+        name="search", help="Full-text search using FTS5. Returns observations ranked by relevance."
+    )(search.search)
+    app.command(name="retrieve")(retrieve.retrieve)
+    app.command(name="list", help="List recent observations in reverse chronological order.")(
+        list.list_observations
+    )
+    app.command(name="get", help="Get a single observation by ID (accepts 8+ char prefix).")(
+        get.get
+    )
+    app.command(name="delete")(delete.delete)
+    app.command(name="diff")(diff.diff)
+    app.command(name="update")(update.update)
+    app.command(name="context")(context.context)
+    app.command(name="cleanup")(cleanup)
+    app.command(name="health")(health)
+    app.command(name="stats")(stats.stats)
+    app.command(name="clear-slow-queries")(stats.clear_slow_queries)
+    app.command(name="tui")(tui.launch)
+
+    app.add_typer(schedule_app, name="schedule")
+    app.add_typer(telemetry_app, name="telemetry")
+    app.add_typer(query_app, name="query")
+    app.add_typer(session_app, name="session")
+    app.add_typer(sync_app, name="sync")
+    app.add_typer(compact_app, name="compact")
+    app.add_typer(mcp.app, name="mcp")
+    app.add_typer(project_app, name="project")
+    app.add_typer(prompt_app, name="prompt")
+    app.add_typer(export_app, name="export")
+    app.add_typer(import_app, name="import")
+    app.add_typer(workflow_app, name="workflow")
+    app.add_typer(message_app, name="message")
+
+    # Mark registered only after all imports and registrations succeed.
+    # If any import fails, the guard stays False and retry is possible.
+    _commands_registered = True
+
+
+def _get_default_db() -> str:
+    """Lazy default -- only imports container when Typer reads the default."""
+    from src.infrastructure.persistence.container import get_default_db_path
+
+    return str(get_default_db_path())
+
+
+def _get_services(db_path: Path) -> tuple[Any, Any, Any]:
+    """Import and create services on demand. Defers heavy imports to callback."""
+    # Use module-level __getattr__ resolution so test patches work correctly.
+    # These trigger PEP 562 lazy imports on first access.
+    from src.interfaces.cli import main as _self
+
+    return (
+        _self.get_memory_service(db_path),
+        _self.get_telemetry_service(db_path),
+        _self.get_hook_service(),
+    )
 
 
 @app.callback()
 def main(
     ctx: typer.Context,
     db_path: str = typer.Option(
-        str(get_default_db_path()),
+        _get_default_db,
         "--db",
         "-d",
         help="Path to memory database (default: XDG-compliant, env: FORK_MEMORY_DB)",
     ),
 ) -> None:
-    ctx.obj = get_memory_service(Path(db_path))
+    """Manage agent memory observations."""
+    import uuid
+
+    from src.application.services.orchestration.events import SessionStartEvent
+
+    resolved = Path(db_path)
+    service, telemetry, hook_service = _get_services(resolved)
+    ctx.obj = service
 
     # Initialize telemetry session
     session_id = f"cli-{uuid.uuid4().hex[:8]}"
-    telemetry = get_telemetry_service(Path(db_path))
     if telemetry.is_enabled and not telemetry.session_id:
         telemetry.start_session(session_id=session_id)
 
-    # Dispatch session start event using the shared singleton to avoid duplicate hooks.json parsing
+    # Dispatch session start event
     try:
-        get_hook_service().dispatch(SessionStartEvent(session_id=session_id))
+        hook_service.dispatch(SessionStartEvent(session_id=session_id))
     except Exception as e:
         logger.debug("Hook dispatch failed [session_start]: %s", e)
 
 
 def _build_cli() -> click.Command:
     """Build the final Click command with all sub-apps including Click-based workspace."""
+    _register_commands()
     click_app = typer.main.get_command(app)
     if isinstance(click_app, click.Group):
+        from src.interfaces.cli.workspace_commands import workspace as workspace_click_group
+
         click_app.add_command(workspace_click_group, name="workspace")
     return click_app
 
 
-cli = _build_cli()
+class _LazyCLI:
+    """Proxy that builds the real CLI on first invocation."""
+
+    def __init__(self) -> None:
+        self._cli: click.Command | None = None
+
+    def _ensure_cli(self) -> click.Command:
+        if self._cli is None:
+            self._cli = _build_cli()
+        return self._cli
+
+    def __call__(self, *args: object, **kwargs: object) -> object:
+        return self._ensure_cli()(*args, **kwargs)
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._ensure_cli(), name)
+
+
+cli = _LazyCLI()
 
 
 if __name__ == "__main__":

--- a/src/interfaces/mcp/tools/_shared.py
+++ b/src/interfaces/mcp/tools/_shared.py
@@ -42,7 +42,8 @@ def _detect_project() -> str:
     """
     import os
 
-    return os.path.basename(os.getcwd())
+    name = os.path.basename(os.getcwd())
+    return name or "default"
 
 
 def _resolve_project(project: str | None) -> str:
@@ -110,7 +111,10 @@ def init_service(db_path: str | None = None) -> None:
     global _custom_db_path
     from pathlib import Path
 
-    _custom_db_path = Path(db_path) if db_path else None
+    new_path = Path(db_path) if db_path else None
+    if new_path != _custom_db_path:
+        _singletons.clear()
+    _custom_db_path = new_path
     _get_memory_service()
     _get_session_service()
     _get_health_service()

--- a/src/interfaces/mcp/tools/memory.py
+++ b/src/interfaces/mcp/tools/memory.py
@@ -43,8 +43,9 @@ def _cap_json_response(
     if estimate_tokens(raw_json) > effective_max:
         serialized = data if isinstance(data, list) else [data]
         serialized = cap_response(serialized, effective_max)
-        if isinstance(data, dict) and serialized:
-            return json.dumps(serialized[0])
+        if isinstance(data, dict):
+            # Preserve object shape — return first item or empty dict, never a list
+            return json.dumps(serialized[0] if serialized else {})
         return json.dumps(serialized)
     return raw_json
 

--- a/tests/unit/interfaces/cli/test_main.py
+++ b/tests/unit/interfaces/cli/test_main.py
@@ -25,6 +25,8 @@ class TestMainApp:
         assert "Manage agent memory observations" in help_text
 
     def test_commands_registered(self) -> None:
+        # Trigger lazy command registration before checking
+        main._register_commands()
         commands = list(main.app.registered_commands)
         command_names = [cmd.name for cmd in commands]
         assert "save" in command_names


### PR DESCRIPTION
## Summary

Combines and supersedes:
- **PR #31** — CLI cold start optimization (import_ms 180→16, -91%)
- **PR #32** — Bot review fixes (Copilot/CodeRabbit/Codex)

Both PRs are closed in favor of this single clean commit with zero merge conflicts.

### CLI Cold Start Optimization

| Change | File | Impact |
|--------|------|--------|
| PEP 562 lazy imports | `cli/__init__.py` | Defers fork.py (82ms, 40 modules) |
| `_LazyCLI` proxy | `cli/main.py` | Defers command registration to first invocation |
| Guard after imports | `cli/main.py` | `_commands_registered` set only after success |

### Bot Review Fixes

| Change | File | Source |
|--------|------|--------|
| Clear `_singletons` on db_path change | `_shared.py` | Codex P1, CodeRabbit |
| Fallback to "default" for empty basename | `_shared.py` | Copilot |
| Preserve dict shape in `_cap_json_response` | `memory.py` | Codex P2, Copilot |
| Match Protocol `bucket_duration` + noqa | `telemetry_repository.py` | Copilot, CodeRabbit |

### Verification
- 1652 tests pass, 0 failures
- ruff clean, mypy clean (pre-existing errors in unrelated files)
- import_ms: 16ms warm, 34ms cold (down from 180ms)
- CLI benchmark: all 44 commands functional

Closes #31, Closes #32
