### PR TITLE
fix(mcp): add explicit re-raise in except BaseException blocks

### DIFF
--- a/src/interfaces/mcp/tools/messaging.py
+++ b/src/interfaces/mcp/tools/messaging.py
@@ -73,6 +73,7 @@ def fork_message_send(
         from mcp import McpError
         if isinstance(_e, McpError):
             raise
+        raise _e
     except Exception as e:
         logger.error("fork_message_send failed: %s", e, exc_info=True)
         raise _map_error(e) from e
@@ -112,6 +113,7 @@ def fork_message_receive(
         from mcp import McpError
         if isinstance(_e, McpError):
             raise
+        raise _e
     except Exception as e:
         logger.error("fork_message_receive failed: %s", e, exc_info=True)
         raise _map_error(e) from e
@@ -144,6 +146,7 @@ def fork_message_broadcast(
         from mcp import McpError
         if isinstance(_e, McpError):
             raise
+        raise _e
     except Exception as e:
         logger.error("fork_message_broadcast failed: %s", e, exc_info=True)
         raise _map_error(e) from e
@@ -176,6 +179,7 @@ def fork_message_history(
         from mcp import McpError
         if isinstance(_e, McpError):
             raise
+        raise _e
     except Exception as e:
         logger.error("fork_message_history failed: %s", e, exc_info=True)
         raise _map_error(e) from e


### PR DESCRIPTION
Fixes mypy regression from PR #34. The except BaseException blocks could fall through without re-raising non-McpError exceptions.