### PR TITLE
feat(workflow): add protocol preflight gate before execute

### DIFF
--- a/src/application/services/orchestration/protocol_preflight.py
+++ b/src/application/services/orchestration/protocol_preflight.py
@@ -1,0 +1,186 @@
+"""Minimal protocol preflight for workflow execution.
+
+This gate is intentionally small. It does not make the full
+``tmux-fork-orchestrator`` protocol authoritative; it only blocks obviously
+unsafe workflow execution before agent spawn.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+from src.application.services.workflow.state import PlanState, WorkflowPhase
+
+MANAGED_SESSION_PREFIXES = ("fork-", "agent-", "opencode-")
+MAX_MANAGED_SESSIONS = 5
+
+
+@dataclass(frozen=True)
+class ProtocolPreflightResult:
+    """Structured result for the workflow protocol preflight."""
+
+    passed: bool
+    failures: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    checked_items: list[str] = field(default_factory=list)
+    bypass_used: bool = False
+
+
+class ProtocolPreflightService:
+    """Fail-closed preflight checks before workflow agent spawn."""
+
+    def __init__(
+        self,
+        *,
+        cwd: Path | None = None,
+        plan_state_path: Path | None = None,
+        max_managed_sessions: int = MAX_MANAGED_SESSIONS,
+    ) -> None:
+        self._cwd = cwd or Path.cwd()
+        self._plan_state_path = plan_state_path
+        self._max_managed_sessions = max_managed_sessions
+
+    def run(self, *, allow_missing_init_bypass: bool = False) -> ProtocolPreflightResult:
+        """Run minimal preflight checks.
+
+        Args:
+            allow_missing_init_bypass: Transitional bypass for missing
+                ``.fork/init.yaml`` only. Other failures remain fail-closed.
+        """
+        failures: list[str] = []
+        warnings: list[str] = []
+        checked: list[str] = []
+        bypass_used = False
+
+        repo_root = self._resolve_repo_root(failures, checked)
+        self._check_tmux_available(failures, checked)
+        self._check_plan_state(failures, checked)
+        if repo_root is not None:
+            init_result = self._check_fork_init_yaml(repo_root, failures, warnings, checked)
+            if init_result == "missing" and allow_missing_init_bypass:
+                failures.remove("Missing .fork/init.yaml; run fork init before workflow execute.")
+                warnings.append(
+                    "Protocol gate bypass used: missing .fork/init.yaml was allowed by "
+                    "--no-protocol-gate."
+                )
+                bypass_used = True
+        self._check_managed_session_limit(failures, checked)
+
+        return ProtocolPreflightResult(
+            passed=not failures,
+            failures=failures,
+            warnings=warnings,
+            checked_items=checked,
+            bypass_used=bypass_used,
+        )
+
+    def _resolve_repo_root(self, failures: list[str], checked: list[str]) -> Path | None:
+        checked.append("repo_root")
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                cwd=self._cwd,
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            failures.append(f"Cannot resolve git repository root: {exc}")
+            return None
+
+        if result.returncode != 0 or not result.stdout.strip():
+            stderr = result.stderr.strip() or "not a git repository"
+            failures.append(f"Cannot resolve git repository root: {stderr}")
+            return None
+        return Path(result.stdout.strip())
+
+    def _check_tmux_available(self, failures: list[str], checked: list[str]) -> None:
+        checked.append("tmux_available")
+        if shutil.which("tmux") is None:
+            failures.append("tmux is not available on PATH; workflow execute cannot spawn agents.")
+
+    def _check_plan_state(self, failures: list[str], checked: list[str]) -> None:
+        checked.append("workflow_state")
+        if self._plan_state_path is None:
+            failures.append("Plan state path was not provided to protocol preflight.")
+            return
+
+        try:
+            plan = PlanState.load(self._plan_state_path)
+        except Exception as exc:
+            failures.append(f"Plan state is invalid or corrupt: {exc}")
+            return
+
+        if plan is None:
+            failures.append("No plan state found. Run 'memory workflow outline' first.")
+            return
+
+        if plan.phase not in (WorkflowPhase.OUTLINED, WorkflowPhase.EXECUTED):
+            failures.append(
+                "Plan state phase does not allow execute: "
+                f"current={plan.phase.value}, allowed=outlined,executed."
+            )
+
+    def _check_fork_init_yaml(
+        self,
+        repo_root: Path,
+        failures: list[str],
+        warnings: list[str],
+        checked: list[str],
+    ) -> str:
+        checked.append("fork_init_yaml")
+        init_path = repo_root / ".fork" / "init.yaml"
+        if not init_path.exists():
+            failures.append("Missing .fork/init.yaml; run fork init before workflow execute.")
+            return "missing"
+
+        try:
+            with init_path.open() as f:
+                yaml.safe_load(f)
+        except yaml.YAMLError as exc:
+            failures.append(f".fork/init.yaml is invalid YAML: {exc}")
+            return "invalid"
+        except OSError as exc:
+            failures.append(f"Cannot read .fork/init.yaml: {exc}")
+            return "invalid"
+
+        warnings.append(".fork/init.yaml detected and parsed; treated as preflight signal only.")
+        return "valid"
+
+    def _check_managed_session_limit(self, failures: list[str], checked: list[str]) -> None:
+        checked.append("managed_tmux_session_limit")
+        if shutil.which("tmux") is None:
+            return
+
+        try:
+            result = subprocess.run(
+                ["tmux", "list-sessions", "-F", "#{session_name}"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            failures.append(f"Cannot count managed tmux sessions: {exc}")
+            return
+
+        if result.returncode != 0:
+            stderr = result.stderr.lower()
+            if "no server running" in stderr or "failed to connect" in stderr:
+                return
+            failures.append(f"Cannot count managed tmux sessions: {result.stderr.strip()}")
+            return
+
+        session_names = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+        managed = [s for s in session_names if s.startswith(MANAGED_SESSION_PREFIXES)]
+        if len(managed) >= self._max_managed_sessions:
+            failures.append(
+                f"Managed tmux session limit reached: {len(managed)} active "
+                f"(max {self._max_managed_sessions}). Cleanup before workflow execute."
+            )

--- a/src/interfaces/cli/commands/workflow.py
+++ b/src/interfaces/cli/commands/workflow.py
@@ -27,6 +27,10 @@ from src.application.services.orchestration.events import (
     WorktreeRemovedEvent,
 )
 from src.application.services.orchestration.hook_service import HookService
+from src.application.services.orchestration.protocol_preflight import (
+    ProtocolPreflightResult,
+    ProtocolPreflightService,
+)
 from src.application.services.workflow.state import (
     ExecuteState,
     PlanState,
@@ -82,7 +86,7 @@ def _get_hook_service() -> HookService:
             return cast(HookService, ctx.obj["hook_service"])
     except RuntimeError:
         pass
-    return _get_shared_hook_service()
+    return cast(HookService, _get_shared_hook_service())
 
 
 def _dispatch_event(event: object, context: str = "") -> None:
@@ -131,6 +135,23 @@ def _send_workflow_message(phase: str, status: str, **kwargs: object) -> None:
         logger.debug("Sent workflow message: %s %s", phase, status)
     except Exception as e:
         logger.debug("Failed to send workflow message [%s:%s]: %s", phase, status, e)
+
+
+def _record_protocol_preflight_bypass(result: ProtocolPreflightResult) -> None:
+    """Persist protocol preflight bypass metadata best-effort."""
+    try:
+        memory = get_memory_service()
+        memory.save(
+            content="workflow:execute:protocol_preflight_bypass",
+            metadata={
+                "phase": "execute",
+                "event": "protocol_preflight_bypass",
+                "checked_items": result.checked_items,
+                "warnings": result.warnings,
+            },
+        )
+    except Exception as e:
+        logger.debug("Failed to save protocol preflight bypass event: %s", e)
 
 
 def _record_ship_event(event_name: str, metadata: dict[str, object]) -> None:
@@ -431,6 +452,11 @@ def execute(
     messaging: bool = typer.Option(
         True, "--messaging", help="Enable inter-agent messaging for coordination (default: enabled)"
     ),
+    no_protocol_gate: bool = typer.Option(
+        False,
+        "--no-protocol-gate",
+        help="Temporarily bypass only the missing .fork/init.yaml preflight failure.",
+    ),
 ) -> None:
     """Execute workflow plan tasks.
 
@@ -438,6 +464,21 @@ def execute(
     worktree creation, and event dispatching.
     """
     from src.interfaces.cli.dependencies import get_workflow_executor
+
+    plan_path = get_plan_state_path()
+    preflight = ProtocolPreflightService(plan_state_path=plan_path).run(
+        allow_missing_init_bypass=no_protocol_gate
+    )
+    for warning in preflight.warnings:
+        typer.echo(f"Warning: {warning}", err=True)
+    if preflight.bypass_used:
+        typer.echo("WARNING: --no-protocol-gate bypass used; this is audited best-effort.", err=True)
+        _record_protocol_preflight_bypass(preflight)
+    if not preflight.passed:
+        typer.echo("Error: workflow execute preflight failed.", err=True)
+        for failure in preflight.failures:
+            typer.echo(f"  - {failure}", err=True)
+        raise typer.Exit(1)  # noqa: B904
 
     plan = _check_plan_exists()
 

--- a/src/interfaces/cli/commands/workflow.py
+++ b/src/interfaces/cli/commands/workflow.py
@@ -13,8 +13,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import cast
 
+import click
 import typer
-from typer import Context
 
 from src.application.exceptions import PhaseSkipError
 from src.application.services.orchestration.events import (
@@ -80,7 +80,9 @@ class ShipPreflightError(Exception):
 def _get_hook_service() -> HookService:
     """Get HookService from ctx.obj if available (for testability), else use shared singleton."""
     try:
-        ctx = cast(Context, typer.get_current_context())
+        ctx = click.get_current_context(silent=True)
+        if ctx is None:
+            return cast(HookService, _get_shared_hook_service())
         if isinstance(ctx.obj, dict):
             if "hook_service" not in ctx.obj:
                 ctx.obj["hook_service"] = _get_shared_hook_service()

--- a/src/interfaces/cli/commands/workflow.py
+++ b/src/interfaces/cli/commands/workflow.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import cast
 
 import typer
+from typer import Context
 
 from src.application.exceptions import PhaseSkipError
 from src.application.services.orchestration.events import (
@@ -79,7 +80,7 @@ class ShipPreflightError(Exception):
 def _get_hook_service() -> HookService:
     """Get HookService from ctx.obj if available (for testability), else use shared singleton."""
     try:
-        ctx = typer.get_current_context()  # type: ignore[attr-defined]
+        ctx = cast(Context, typer.get_current_context())
         if isinstance(ctx.obj, dict):
             if "hook_service" not in ctx.obj:
                 ctx.obj["hook_service"] = _get_shared_hook_service()
@@ -472,7 +473,9 @@ def execute(
     for warning in preflight.warnings:
         typer.echo(f"Warning: {warning}", err=True)
     if preflight.bypass_used:
-        typer.echo("WARNING: --no-protocol-gate bypass used; this is audited best-effort.", err=True)
+        typer.echo(
+            "WARNING: --no-protocol-gate bypass used; this is audited best-effort.", err=True
+        )
         _record_protocol_preflight_bypass(preflight)
     if not preflight.passed:
         typer.echo("Error: workflow execute preflight failed.", err=True)

--- a/tests/unit/application/services/orchestration/test_protocol_preflight.py
+++ b/tests/unit/application/services/orchestration/test_protocol_preflight.py
@@ -1,0 +1,157 @@
+"""Tests for minimal workflow protocol preflight."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from src.application.services.orchestration.protocol_preflight import ProtocolPreflightService
+from src.application.services.workflow.state import PlanState, WorkflowPhase
+
+
+def _save_plan(path: Path, phase: WorkflowPhase = WorkflowPhase.OUTLINED) -> None:
+    PlanState(session_id="plan-1", phase=phase).save(path)
+
+
+def _completed(stdout: str = "", stderr: str = "", returncode: int = 0) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def _patch_runtime(
+    monkeypatch: Any,
+    repo_root: Path,
+    *,
+    tmux_path: str | None = "/usr/bin/tmux",
+    sessions: list[str] | None = None,
+) -> None:
+    sessions = sessions or []
+
+    def fake_which(cmd: str) -> str | None:
+        if cmd == "tmux":
+            return tmux_path
+        return f"/usr/bin/{cmd}"
+
+    def fake_run(cmd: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        if cmd[:3] == ["git", "rev-parse", "--show-toplevel"]:
+            return _completed(stdout=str(repo_root))
+        if cmd[:3] == ["tmux", "list-sessions", "-F"]:
+            return _completed(stdout="\n".join(sessions))
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr("shutil.which", fake_which)
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+
+def test_valid_init_allows_preflight(monkeypatch: Any, tmp_path: Path) -> None:
+    _patch_runtime(monkeypatch, tmp_path)
+    plan_path = tmp_path / "plan-state.json"
+    _save_plan(plan_path)
+    init_path = tmp_path / ".fork" / "init.yaml"
+    init_path.parent.mkdir()
+    init_path.write_text("project_name: tmux_fork\nlanguage: python\n")
+
+    result = ProtocolPreflightService(cwd=tmp_path, plan_state_path=plan_path).run()
+
+    assert result.passed is True
+    assert "fork_init_yaml" in result.checked_items
+    assert result.bypass_used is False
+
+
+def test_missing_init_blocks_by_default(monkeypatch: Any, tmp_path: Path) -> None:
+    _patch_runtime(monkeypatch, tmp_path)
+    plan_path = tmp_path / "plan-state.json"
+    _save_plan(plan_path)
+
+    result = ProtocolPreflightService(cwd=tmp_path, plan_state_path=plan_path).run()
+
+    assert result.passed is False
+    assert any("Missing .fork/init.yaml" in failure for failure in result.failures)
+
+
+def test_missing_init_can_be_bypassed_explicitly(monkeypatch: Any, tmp_path: Path) -> None:
+    _patch_runtime(monkeypatch, tmp_path)
+    plan_path = tmp_path / "plan-state.json"
+    _save_plan(plan_path)
+
+    result = ProtocolPreflightService(cwd=tmp_path, plan_state_path=plan_path).run(
+        allow_missing_init_bypass=True
+    )
+
+    assert result.passed is True
+    assert result.bypass_used is True
+    assert any("bypass used" in warning for warning in result.warnings)
+
+
+def test_tmux_missing_blocks(monkeypatch: Any, tmp_path: Path) -> None:
+    _patch_runtime(monkeypatch, tmp_path, tmux_path=None)
+    plan_path = tmp_path / "plan-state.json"
+    _save_plan(plan_path)
+    init_path = tmp_path / ".fork" / "init.yaml"
+    init_path.parent.mkdir()
+    init_path.write_text("project_name: tmux_fork\n")
+
+    result = ProtocolPreflightService(cwd=tmp_path, plan_state_path=plan_path).run()
+
+    assert result.passed is False
+    assert any("tmux is not available" in failure for failure in result.failures)
+
+
+def test_managed_session_limit_blocks(monkeypatch: Any, tmp_path: Path) -> None:
+    _patch_runtime(
+        monkeypatch,
+        tmp_path,
+        sessions=["fork-a", "agent-b", "opencode-c", "fork-d", "agent-e"],
+    )
+    plan_path = tmp_path / "plan-state.json"
+    _save_plan(plan_path)
+    init_path = tmp_path / ".fork" / "init.yaml"
+    init_path.parent.mkdir()
+    init_path.write_text("project_name: tmux_fork\n")
+
+    result = ProtocolPreflightService(cwd=tmp_path, plan_state_path=plan_path).run()
+
+    assert result.passed is False
+    assert any("Managed tmux session limit reached" in failure for failure in result.failures)
+
+
+def test_invalid_init_yaml_blocks(monkeypatch: Any, tmp_path: Path) -> None:
+    _patch_runtime(monkeypatch, tmp_path)
+    plan_path = tmp_path / "plan-state.json"
+    _save_plan(plan_path)
+    init_path = tmp_path / ".fork" / "init.yaml"
+    init_path.parent.mkdir()
+    init_path.write_text("project_name: [broken\n")
+
+    result = ProtocolPreflightService(cwd=tmp_path, plan_state_path=plan_path).run()
+
+    assert result.passed is False
+    assert any("invalid YAML" in failure for failure in result.failures)
+
+
+def test_corrupt_plan_state_blocks_with_clear_message(monkeypatch: Any, tmp_path: Path) -> None:
+    _patch_runtime(monkeypatch, tmp_path)
+    plan_path = tmp_path / "plan-state.json"
+    plan_path.write_text("{bad json")
+    init_path = tmp_path / ".fork" / "init.yaml"
+    init_path.parent.mkdir()
+    init_path.write_text("project_name: tmux_fork\n")
+
+    result = ProtocolPreflightService(cwd=tmp_path, plan_state_path=plan_path).run()
+
+    assert result.passed is False
+    assert any("Plan state is invalid or corrupt" in failure for failure in result.failures)
+
+
+def test_invalid_phase_blocks(monkeypatch: Any, tmp_path: Path) -> None:
+    _patch_runtime(monkeypatch, tmp_path)
+    plan_path = tmp_path / "plan-state.json"
+    _save_plan(plan_path, phase=WorkflowPhase.PLANNING)
+    init_path = tmp_path / ".fork" / "init.yaml"
+    init_path.parent.mkdir()
+    init_path.write_text("project_name: tmux_fork\n")
+
+    result = ProtocolPreflightService(cwd=tmp_path, plan_state_path=plan_path).run()
+
+    assert result.passed is False
+    assert any("phase does not allow execute" in failure for failure in result.failures)

--- a/tests/unit/application/services/orchestration/test_protocol_preflight.py
+++ b/tests/unit/application/services/orchestration/test_protocol_preflight.py
@@ -14,7 +14,9 @@ def _save_plan(path: Path, phase: WorkflowPhase = WorkflowPhase.OUTLINED) -> Non
     PlanState(session_id="plan-1", phase=phase).save(path)
 
 
-def _completed(stdout: str = "", stderr: str = "", returncode: int = 0) -> subprocess.CompletedProcess[str]:
+def _completed(
+    stdout: str = "", stderr: str = "", returncode: int = 0
+) -> subprocess.CompletedProcess[str]:
     return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
 
 

--- a/tests/unit/interfaces/cli/commands/test_workflow.py
+++ b/tests/unit/interfaces/cli/commands/test_workflow.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from typer.testing import CliRunner
 
+from src.application.services.orchestration.protocol_preflight import ProtocolPreflightResult
 from src.application.services.workflow.state import (
     ExecuteState,
     PlanState,
@@ -76,6 +77,13 @@ class TestWorkflowExecute:
         plan_path = tmp_path / "plan-state.json"
         plan_state.save(plan_path)
 
+        executor = MagicMock()
+        executor.execute_plan.return_value = MagicMock(
+            exec_state=ExecuteState(session_id="exec-1", phase=WorkflowPhase.EXECUTED),
+            spawned_sessions=["fork-worker-1"],
+            errors=[],
+        )
+
         with (
             patch(
                 "src.interfaces.cli.commands.workflow.get_plan_state_path",
@@ -85,11 +93,98 @@ class TestWorkflowExecute:
                 "src.interfaces.cli.commands.workflow.get_execute_state_path",
                 return_value=tmp_path / "execute-state.json",
             ),
+            patch(
+                "src.interfaces.cli.commands.workflow.ProtocolPreflightService.run",
+                return_value=ProtocolPreflightResult(passed=True, checked_items=["repo_root"]),
+            ),
+            patch(
+                "src.interfaces.cli.dependencies.get_workflow_executor",
+                return_value=executor,
+            ),
         ):
             result = runner.invoke(get_app(), ["execute"])
 
         assert result.exit_code == 0
         assert "Execution started" in result.stdout
+
+    def test_execute_blocks_when_preflight_fails(self, tmp_path: Path) -> None:
+        plan_state = PlanState(session_id="test-session", phase=WorkflowPhase.OUTLINED)
+        plan_path = tmp_path / "plan-state.json"
+        plan_state.save(plan_path)
+        executor = MagicMock()
+        execute_path = tmp_path / "execute-state.json"
+
+        with (
+            patch(
+                "src.interfaces.cli.commands.workflow.get_plan_state_path",
+                return_value=plan_path,
+            ),
+            patch(
+                "src.interfaces.cli.commands.workflow.get_execute_state_path",
+                return_value=execute_path,
+            ),
+            patch(
+                "src.interfaces.cli.commands.workflow.ProtocolPreflightService.run",
+                return_value=ProtocolPreflightResult(
+                    passed=False,
+                    failures=["tmux is not available on PATH; workflow execute cannot spawn agents."],
+                    checked_items=["tmux_available"],
+                ),
+            ),
+            patch(
+                "src.interfaces.cli.dependencies.get_workflow_executor",
+                return_value=executor,
+            ),
+        ):
+            result = runner.invoke(get_app(), ["execute"])
+
+        assert result.exit_code == 1
+        assert "workflow execute preflight failed" in result.output
+        assert "tmux is not available" in result.output
+        executor.execute_plan.assert_not_called()
+        assert not execute_path.exists()
+
+    def test_execute_no_protocol_gate_audits_bypass(self, tmp_path: Path) -> None:
+        plan_state = PlanState(session_id="test-session", phase=WorkflowPhase.OUTLINED)
+        plan_path = tmp_path / "plan-state.json"
+        plan_state.save(plan_path)
+        executor = MagicMock()
+        executor.execute_plan.return_value = MagicMock(
+            exec_state=ExecuteState(session_id="exec-1", phase=WorkflowPhase.EXECUTED),
+            spawned_sessions=[],
+            errors=[],
+        )
+        memory = MagicMock()
+
+        with (
+            patch(
+                "src.interfaces.cli.commands.workflow.get_plan_state_path",
+                return_value=plan_path,
+            ),
+            patch(
+                "src.interfaces.cli.commands.workflow.get_execute_state_path",
+                return_value=tmp_path / "execute-state.json",
+            ),
+            patch(
+                "src.interfaces.cli.commands.workflow.ProtocolPreflightService.run",
+                return_value=ProtocolPreflightResult(
+                    passed=True,
+                    warnings=["Protocol gate bypass used: missing .fork/init.yaml was allowed by --no-protocol-gate."],
+                    checked_items=["fork_init_yaml"],
+                    bypass_used=True,
+                ),
+            ),
+            patch(
+                "src.interfaces.cli.dependencies.get_workflow_executor",
+                return_value=executor,
+            ),
+            patch("src.interfaces.cli.commands.workflow.get_memory_service", return_value=memory),
+        ):
+            result = runner.invoke(get_app(), ["execute", "--no-protocol-gate"])
+
+        assert result.exit_code == 0
+        assert "--no-protocol-gate bypass used" in result.output
+        memory.save.assert_called_once()
 
 
 class TestWorkflowVerify:
@@ -233,9 +328,12 @@ class TestWorkflowShip:
         verify_path = tmp_path / "verify-state.json"
         verify_state.save(verify_path)
 
-        with patch(
-            "src.interfaces.cli.commands.workflow.get_verify_state_path",
-            return_value=verify_path,
+        with (
+            patch(
+                "src.interfaces.cli.commands.workflow.get_verify_state_path",
+                return_value=verify_path,
+            ),
+            patch("src.interfaces.cli.commands.workflow._enforce_ship_checkout_preflight"),
         ):
             result = runner.invoke(get_app(), ["ship"])
 
@@ -250,9 +348,12 @@ class TestWorkflowShip:
         verify_path = tmp_path / "verify-state.json"
         verify_state.save(verify_path)
 
-        with patch(
-            "src.interfaces.cli.commands.workflow.get_verify_state_path",
-            return_value=verify_path,
+        with (
+            patch(
+                "src.interfaces.cli.commands.workflow.get_verify_state_path",
+                return_value=verify_path,
+            ),
+            patch("src.interfaces.cli.commands.workflow._enforce_ship_checkout_preflight"),
         ):
             result = runner.invoke(get_app(), ["ship"])
 
@@ -278,6 +379,7 @@ class TestWorkflowShip:
                 "src.interfaces.cli.commands.workflow.get_verify_state_path",
                 return_value=verify_path,
             ),
+            patch("src.interfaces.cli.commands.workflow._enforce_ship_checkout_preflight"),
             patch(
                 "src.interfaces.cli.commands.workflow._dispatch_event",
                 side_effect=lambda event, _context="", **_kwargs: dispatched.append(event),

--- a/tests/unit/interfaces/cli/commands/test_workflow.py
+++ b/tests/unit/interfaces/cli/commands/test_workflow.py
@@ -29,7 +29,6 @@ class TestWorkflowOutline:
     """Tests for workflow outline command."""
 
     def test_outline_creates_plan_state(self, tmp_path: Path) -> None:
-
         plan_file = tmp_path / "plan.md"
         with patch(
             "src.interfaces.cli.commands.workflow.get_plan_state_path",
@@ -44,7 +43,6 @@ class TestWorkflowOutline:
         assert "Plan created:" in result.stdout
 
     def test_outline_requires_task_description(self) -> None:
-
         result = runner.invoke(get_app(), ["outline"])
 
         assert result.exit_code != 0
@@ -72,7 +70,6 @@ class TestWorkflowExecute:
         assert result.exit_code == 1
 
     def test_execute_with_existing_plan(self, tmp_path: Path) -> None:
-
         plan_state = PlanState(session_id="test-session", phase=WorkflowPhase.OUTLINED)
         plan_path = tmp_path / "plan-state.json"
         plan_state.save(plan_path)
@@ -127,7 +124,9 @@ class TestWorkflowExecute:
                 "src.interfaces.cli.commands.workflow.ProtocolPreflightService.run",
                 return_value=ProtocolPreflightResult(
                     passed=False,
-                    failures=["tmux is not available on PATH; workflow execute cannot spawn agents."],
+                    failures=[
+                        "tmux is not available on PATH; workflow execute cannot spawn agents."
+                    ],
                     checked_items=["tmux_available"],
                 ),
             ),
@@ -169,7 +168,9 @@ class TestWorkflowExecute:
                 "src.interfaces.cli.commands.workflow.ProtocolPreflightService.run",
                 return_value=ProtocolPreflightResult(
                     passed=True,
-                    warnings=["Protocol gate bypass used: missing .fork/init.yaml was allowed by --no-protocol-gate."],
+                    warnings=[
+                        "Protocol gate bypass used: missing .fork/init.yaml was allowed by --no-protocol-gate."
+                    ],
                     checked_items=["fork_init_yaml"],
                     bypass_used=True,
                 ),
@@ -214,7 +215,6 @@ class TestWorkflowVerify:
         assert result.exit_code == 1
 
     def test_verify_success(self, tmp_path: Path) -> None:
-
         plan_state = PlanState(session_id="test-session", phase=WorkflowPhase.OUTLINED)
         exec_state = ExecuteState(session_id="test-exec", phase=WorkflowPhase.EXECUTED)
 
@@ -321,7 +321,6 @@ class TestWorkflowShip:
         assert result.exit_code == 1
 
     def test_ship_blocked_without_unlock(self, tmp_path: Path) -> None:
-
         verify_state = VerifyState(
             session_id="test-verify", unlock_ship=False, phase=WorkflowPhase.VERIFIED
         )
@@ -341,7 +340,6 @@ class TestWorkflowShip:
         assert "Verification not complete" in result.output
 
     def test_ship_allowed_with_unlock(self, tmp_path: Path) -> None:
-
         verify_state = VerifyState(
             session_id="test-verify", unlock_ship=True, phase=WorkflowPhase.VERIFIED
         )
@@ -537,7 +535,6 @@ class TestWorkflowStatus:
         assert "Workflow Status" in result.stdout
 
     def test_status_with_plan(self, tmp_path: Path) -> None:
-
         plan_state = PlanState(session_id="test-plan", phase=WorkflowPhase.OUTLINED)
         plan_path = tmp_path / "plan-state.json"
         plan_state.save(plan_path)


### PR DESCRIPTION
## Summary
- Adds a minimal fail-closed protocol preflight before workflow execute.
- Blocks execute before agent spawn when tmux/protocol/state/session checks fail.
- Keeps WO-PROTO-001A scoped to workflow execute preflight only.

## Test Plan
- [x] uv run pytest tests/unit/application/services/orchestration/test_protocol_preflight.py -v
- [x] uv run pytest tests/unit/interfaces/cli/commands/test_workflow.py -v
- [x] uv run ruff check src/application/services/orchestration/protocol_preflight.py src/interfaces/cli/commands/workflow.py tests/unit/application/services/orchestration/test_protocol_preflight.py tests/unit/interfaces/cli/commands/test_workflow.py
- [x] uv run mypy src/application/services/orchestration/protocol_preflight.py

## Risks / Follow-ups
- Replaces contaminated draft PR #36 with a clean branch based on origin/main.
- This does not implement prompt @file, envelope validation, conflict detection, cleanup doctor, or full protocol authority.