### PR TITLE
feat(fpel): wire hash authority — call sites pass current_hash to check_sealed()

### DIFF
--- a/src/application/services/fpel_authorization_service.py
+++ b/src/application/services/fpel_authorization_service.py
@@ -127,6 +127,40 @@ class FPELAuthorizationService:
         self._repo.save_frozen_proposal(proposal)
         return proposal
 
+    def freeze_task(
+        self, target_id: str, plan_text: str | None, subject: str, description: str | None = None
+    ) -> FrozenProposal:
+        """Freeze with canonical hash from an OrchestrationTask's content.
+
+        Computes the same hash as ``compute_task_hash()`` so that
+        ``check_sealed(current_hash=...)`` produces consistent results.
+        """
+        content = plan_text
+        if content is None:
+            parts = [subject]
+            if description:
+                parts.append(description)
+            content = "\n".join(parts)
+        return self.freeze(target_id, content)
+
+    def freeze_plan(self, target_id: str, tasks: list[dict[str, str]]) -> FrozenProposal:
+        """Freeze with canonical hash from a plan's task list.
+
+        Computes the same hash as ``compute_plan_hash_from_tasks()`` so that
+        ``check_sealed(current_hash=...)`` produces consistent results.
+
+        Args:
+            target_id: The plan session ID.
+            tasks: List of dicts with id/slug/description keys.
+        """
+        import json
+
+        task_data = [
+            {"id": t["id"], "slug": t["slug"], "description": t["description"]} for t in tasks
+        ]
+        canonical = json.dumps(task_data, sort_keys=True, separators=(",", ":"))
+        return self.freeze(target_id, canonical)
+
     # ------------------------------------------------------------------
     # check
     # ------------------------------------------------------------------

--- a/src/application/services/task_board_service.py
+++ b/src/application/services/task_board_service.py
@@ -203,7 +203,10 @@ class TaskBoardService:
 
         # FPEL gate: sealed PASS required for implementation start
         if self._fpel_port is not None:
-            decision = self._fpel_port.check_sealed(task_id)
+            from src.infrastructure.persistence.fpel_content_hash import compute_task_hash
+
+            current_hash = compute_task_hash(task)
+            decision = self._fpel_port.check_sealed(task_id, current_hash=current_hash)
             if not decision.allowed:
                 from src.application.exceptions import TaskTransitionError
 

--- a/src/application/services/task_board_service.py
+++ b/src/application/services/task_board_service.py
@@ -203,7 +203,7 @@ class TaskBoardService:
 
         # FPEL gate: sealed PASS required for implementation start
         if self._fpel_port is not None:
-            from src.infrastructure.persistence.fpel_content_hash import compute_task_hash
+            from src.domain.services.fpel_content_hash import compute_task_hash
 
             current_hash = compute_task_hash(task)
             decision = self._fpel_port.check_sealed(task_id, current_hash=current_hash)

--- a/src/domain/services/fpel_content_hash.py
+++ b/src/domain/services/fpel_content_hash.py
@@ -1,7 +1,7 @@
-"""FPEL content hash computation for call sites.
+"""FPEL content hash computation — canonical hash functions for domain entities.
 
-Provides canonical hash functions for domain entities (OrchestrationTask,
-PlanState) so that call sites can pass `current_hash` to `check_sealed()`.
+Provides stable SHA-256 hash functions so that freeze() and check_sealed()
+use identical canonicalization for the same target type.
 
 The hash captures the **content** of the entity (what it describes), NOT
 its lifecycle state (status, timestamps). This ensures that post-freeze
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import json
 
-from src.application.services.workflow.state import PlanState
 from src.domain.entities.fpel import compute_content_hash
 from src.domain.entities.orchestration_task import OrchestrationTask
 
@@ -30,7 +29,6 @@ def compute_task_hash(task: OrchestrationTask) -> str:
     """
     content = task.plan_text
     if content is None:
-        # Fallback: canonicalize subject + description
         parts = [task.subject]
         if task.description:
             parts.append(task.description)
@@ -38,20 +36,25 @@ def compute_task_hash(task: OrchestrationTask) -> str:
     return compute_content_hash(content)
 
 
-def compute_plan_hash(plan: PlanState) -> str:
-    """Compute canonical SHA-256 hash of a PlanState's content.
+def compute_plan_task_hash(task_id: str, slug: str, description: str) -> str:
+    """Compute canonical SHA-256 hash of a single plan task's content.
 
-    Serializes the task list (id + slug + description) as canonical JSON.
-    Intentionally excludes: `session_id`, `phase`, `status`, `started_at`,
-    `decisions` — these are lifecycle metadata, not the work content.
+    Used when workflow execute targets a specific task_id — the hash
+    scope matches the task, not the entire plan.
     """
-    task_data = [
-        {
-            "id": t.id,
-            "slug": t.slug,
-            "description": t.description,
-        }
-        for t in plan.tasks
-    ]
+    data = {"id": task_id, "slug": slug, "description": description}
+    canonical = json.dumps(data, sort_keys=True, separators=(",", ":"))
+    return compute_content_hash(canonical)
+
+
+def compute_plan_hash_from_tasks(tasks: list[dict[str, str]]) -> str:
+    """Compute canonical SHA-256 hash of a plan's task list.
+
+    Accepts a list of dicts with id/slug/description keys — no dependency
+    on application-layer types.
+
+    Serializes as sorted JSON to ensure deterministic hashing.
+    """
+    task_data = [{"id": t["id"], "slug": t["slug"], "description": t["description"]} for t in tasks]
     canonical = json.dumps(task_data, sort_keys=True, separators=(",", ":"))
     return compute_content_hash(canonical)

--- a/src/infrastructure/persistence/fpel_content_hash.py
+++ b/src/infrastructure/persistence/fpel_content_hash.py
@@ -1,0 +1,57 @@
+"""FPEL content hash computation for call sites.
+
+Provides canonical hash functions for domain entities (OrchestrationTask,
+PlanState) so that call sites can pass `current_hash` to `check_sealed()`.
+
+The hash captures the **content** of the entity (what it describes), NOT
+its lifecycle state (status, timestamps). This ensures that post-freeze
+drift in the actual work content is detected, while status transitions
+(PLANNING → APPROVED → IN_PROGRESS) do not trigger false positives.
+"""
+
+from __future__ import annotations
+
+import json
+
+from src.application.services.workflow.state import PlanState
+from src.domain.entities.fpel import compute_content_hash
+from src.domain.entities.orchestration_task import OrchestrationTask
+
+
+def compute_task_hash(task: OrchestrationTask) -> str:
+    """Compute canonical SHA-256 hash of an OrchestrationTask's content.
+
+    Uses `plan_text` when present (the substantive content), falling back
+    to `subject` + `description` for tasks without a plan.
+
+    Intentionally excludes: `status`, `owner`, `created_at`, `updated_at`,
+    `approved_by`, `approved_at`, `requested_by` — these are lifecycle
+    metadata, not content.
+    """
+    content = task.plan_text
+    if content is None:
+        # Fallback: canonicalize subject + description
+        parts = [task.subject]
+        if task.description:
+            parts.append(task.description)
+        content = "\n".join(parts)
+    return compute_content_hash(content)
+
+
+def compute_plan_hash(plan: PlanState) -> str:
+    """Compute canonical SHA-256 hash of a PlanState's content.
+
+    Serializes the task list (id + slug + description) as canonical JSON.
+    Intentionally excludes: `session_id`, `phase`, `status`, `started_at`,
+    `decisions` — these are lifecycle metadata, not the work content.
+    """
+    task_data = [
+        {
+            "id": t.id,
+            "slug": t.slug,
+            "description": t.description,
+        }
+        for t in plan.tasks
+    ]
+    canonical = json.dumps(task_data, sort_keys=True, separators=(",", ":"))
+    return compute_content_hash(canonical)

--- a/src/interfaces/cli/commands/fpel.py
+++ b/src/interfaces/cli/commands/fpel.py
@@ -49,12 +49,78 @@ def _require_fpel_service():
 @app.command("freeze")
 def freeze_proposal(
     target_id: Annotated[str, typer.Option("--target-id", help="Target task or workflow ID")],
-    content: Annotated[str, typer.Option("--content", help="Proposal content to freeze")],
+    content: Annotated[
+        str | None,
+        typer.Option(
+            "--content", help="Raw content to freeze (low-level, not hash-authority compliant)"
+        ),
+    ] = None,
+    from_task: Annotated[
+        str | None,
+        typer.Option("--from-task", help="Task ID — freeze with canonical hash from task board"),
+    ] = None,
+    from_plan: Annotated[
+        str | None,
+        typer.Option(
+            "--from-plan", help="Plan session ID — freeze with canonical hash from plan state"
+        ),
+    ] = None,
 ) -> None:
-    """Create an immutable frozen snapshot of a proposal."""
+    """Create an immutable frozen snapshot of a proposal.
+
+    Use --from-task or --from-plan for hash-authority compliant freeze
+    (canonical hash matches what check_sealed() computes at runtime).
+    Use --content for low-level/arbitrary content (not hash-authority compliant).
+    """
+    sources = [content is not None, from_task is not None, from_plan is not None]
+    if sum(sources) != 1:
+        console.print(
+            "[red]Error: Provide exactly one of --content, --from-task, --from-plan[/red]"
+        )
+        raise typer.Exit(1)
 
     service = _require_fpel_service()
-    frozen = service.freeze(target_id=target_id, content=content)
+
+    if from_task is not None:
+        from src.infrastructure.persistence.container import get_container
+
+        container = get_container()
+        task_board = container.task_board_service()
+        task = task_board.get(from_task)
+        if task is None:
+            console.print(f"[red]Error: Task '{from_task}' not found[/red]")
+            raise typer.Exit(1)
+        frozen = service.freeze_task(
+            target_id=target_id,
+            plan_text=task.plan_text,
+            subject=task.subject,
+            description=task.description,
+        )
+    elif from_plan is not None:
+        from src.interfaces.cli.commands.workflow import get_plan_state_path
+
+        plan_path = get_plan_state_path()
+        if not plan_path.exists():
+            console.print("[red]Error: No plan state found. Run 'workflow outline' first.[/red]")
+            raise typer.Exit(1)
+        from src.application.services.workflow.state import PlanState
+
+        plan = PlanState.load(plan_path)
+        if plan is None:
+            console.print("[red]Error: Failed to load plan state.[/red]")
+            raise typer.Exit(1)
+        if plan.session_id != from_plan:
+            console.print(
+                f"[red]Error: Plan session_id '{plan.session_id}' does not match --from-plan '{from_plan}'[/red]"
+            )
+            raise typer.Exit(1)
+        tasks_data = [
+            {"id": t.id, "slug": t.slug, "description": t.description} for t in plan.tasks
+        ]
+        frozen = service.freeze_plan(target_id=target_id, tasks=tasks_data)
+    else:
+        frozen = service.freeze(target_id=target_id, content=content)
+
     console.print("[green]Proposal frozen.[/green]")
     console.print(f"  frozen_proposal_id: {frozen.frozen_proposal_id}")
     console.print(f"  content_hash:       {frozen.content_hash[:16]}...")

--- a/src/interfaces/cli/commands/workflow.py
+++ b/src/interfaces/cli/commands/workflow.py
@@ -475,12 +475,28 @@ def execute(
     # FPEL gate: sealed PASS required for workflow execute
     # target_id semantics: task_id when executing a specific task,
     # plan.session_id when executing the workflow as a whole.
+    # Hash scope must match target scope: task-level hash for task targets,
+    # plan-level hash for workflow targets.
     fpel_port = get_fpel_authorization_port()
     if fpel_port is not None:
-        from src.infrastructure.persistence.fpel_content_hash import compute_plan_hash
+        from src.domain.services.fpel_content_hash import (
+            compute_plan_hash_from_tasks,
+            compute_plan_task_hash,
+        )
 
-        current_hash = compute_plan_hash(plan)
         resolved_target_id = task_id if task_id else plan.session_id
+        if task_id:
+            target_task = next((t for t in plan.tasks if t.id == task_id), None)
+            if target_task is None:
+                typer.echo(f"Error: Task '{task_id}' not found in plan", err=True)
+                raise typer.Exit(1)
+            current_hash = compute_plan_task_hash(
+                target_task.id, target_task.slug, target_task.description
+            )
+        else:
+            current_hash = compute_plan_hash_from_tasks(
+                [{"id": t.id, "slug": t.slug, "description": t.description} for t in plan.tasks]
+            )
         decision = fpel_port.check_sealed(resolved_target_id, current_hash=current_hash)
         if not decision.allowed:
             reason_str = decision.reason.value if decision.reason else "unknown"

--- a/src/interfaces/cli/commands/workflow.py
+++ b/src/interfaces/cli/commands/workflow.py
@@ -477,8 +477,11 @@ def execute(
     # plan.session_id when executing the workflow as a whole.
     fpel_port = get_fpel_authorization_port()
     if fpel_port is not None:
+        from src.infrastructure.persistence.fpel_content_hash import compute_plan_hash
+
+        current_hash = compute_plan_hash(plan)
         resolved_target_id = task_id if task_id else plan.session_id
-        decision = fpel_port.check_sealed(resolved_target_id)
+        decision = fpel_port.check_sealed(resolved_target_id, current_hash=current_hash)
         if not decision.allowed:
             reason_str = decision.reason.value if decision.reason else "unknown"
             typer.echo(

--- a/tests/unit/application/test_task_board_fpel.py
+++ b/tests/unit/application/test_task_board_fpel.py
@@ -247,7 +247,7 @@ class TestHashAuthority:
         call_hash = fpel.check_sealed.call_args[1]["current_hash"]
         assert call_hash is not None
 
-        from src.infrastructure.persistence.fpel_content_hash import compute_task_hash
+        from src.domain.services.fpel_content_hash import compute_task_hash
 
         expected = compute_task_hash(_make_task(plan_text="# Plan A"))
         assert call_hash == expected
@@ -270,7 +270,7 @@ class TestHashAuthority:
             service.start(TASK_ID, owner="worker")
 
         call_hash = fpel.check_sealed.call_args[1]["current_hash"]
-        from src.infrastructure.persistence.fpel_content_hash import compute_task_hash
+        from src.domain.services.fpel_content_hash import compute_task_hash
 
         expected = compute_task_hash(_make_task(plan_text="# Plan B — MODIFIED"))
         assert call_hash == expected

--- a/tests/unit/application/test_task_board_fpel.py
+++ b/tests/unit/application/test_task_board_fpel.py
@@ -99,7 +99,7 @@ def _denied_decision(
 
 class TestStartGatesViaFPEL:
     def test_start_calls_fpel_check_sealed(self) -> None:
-        """start() must call FPELAuthorizationPort.check_sealed()."""
+        """start() must call FPELAuthorizationPort.check_sealed() with current_hash."""
         service, repo, fpel = _make_service_with_fpel()
         repo.get_by_id.return_value = _make_task()
         fpel.check_sealed.return_value = _sealed_pass_decision()
@@ -108,7 +108,12 @@ class TestStartGatesViaFPEL:
             mock_time.time.return_value = NOW_MS / 1000
             service.start(TASK_ID, owner="worker")
 
-        fpel.check_sealed.assert_called_once_with(TASK_ID)
+        fpel.check_sealed.assert_called_once()
+        call_args = fpel.check_sealed.call_args
+        assert call_args[0][0] == TASK_ID
+        assert call_args[1].get("current_hash") is not None, (
+            "check_sealed() MUST receive current_hash from caller"
+        )
 
     def test_sealed_pass_allows_start(self) -> None:
         """Sealed PASS authorizes APPROVED → IN_PROGRESS."""
@@ -221,3 +226,51 @@ class TestBackwardCompat:
             result = service.start(TASK_ID, owner="worker")
 
         assert result.status == OrchestrationTaskStatus.IN_PROGRESS
+
+
+# ---------------------------------------------------------------------------
+# Hash authority: current_hash computed from task content
+# ---------------------------------------------------------------------------
+
+
+class TestHashAuthority:
+    def test_start_passes_content_hash_to_gate(self) -> None:
+        """start() computes current_hash from task and passes to check_sealed."""
+        service, repo, fpel = _make_service_with_fpel()
+        repo.get_by_id.return_value = _make_task(plan_text="# Plan A")
+        fpel.check_sealed.return_value = _sealed_pass_decision()
+
+        with patch("src.application.services.task_board_service.time") as mock_time:
+            mock_time.time.return_value = NOW_MS / 1000
+            service.start(TASK_ID, owner="worker")
+
+        call_hash = fpel.check_sealed.call_args[1]["current_hash"]
+        assert call_hash is not None
+
+        from src.infrastructure.persistence.fpel_content_hash import compute_task_hash
+
+        expected = compute_task_hash(_make_task(plan_text="# Plan A"))
+        assert call_hash == expected
+
+    def test_post_freeze_plan_change_blocks_start(self) -> None:
+        """If plan_text changes after freeze, start() blocked by HASH_MISMATCH."""
+        service, repo, fpel = _make_service_with_fpel()
+        repo.get_by_id.return_value = _make_task(plan_text="# Plan B — MODIFIED")
+        fpel.check_sealed.return_value = AuthorizationDecision(
+            allowed=False,
+            status=FPELStatus.SEALED_PASS,
+            frozen_proposal_id="fp-001",
+            content_hash="original_hash_not_matching",
+            reason=SealFailureReason.HASH_MISMATCH,
+            seal_id=None,
+            sealed_at=None,
+        )
+
+        with pytest.raises(TaskTransitionError, match="sealed PASS"):
+            service.start(TASK_ID, owner="worker")
+
+        call_hash = fpel.check_sealed.call_args[1]["current_hash"]
+        from src.infrastructure.persistence.fpel_content_hash import compute_task_hash
+
+        expected = compute_task_hash(_make_task(plan_text="# Plan B — MODIFIED"))
+        assert call_hash == expected

--- a/tests/unit/application/test_task_board_service.py
+++ b/tests/unit/application/test_task_board_service.py
@@ -568,7 +568,10 @@ class TestFPELSealedGate:
 
         assert result.status == OrchestrationTaskStatus.IN_PROGRESS
         assert result.owner == "worker"
-        mock_fpel.check_sealed.assert_called_once_with(TASK_ID)
+        mock_fpel.check_sealed.assert_called_once()
+        call_args = mock_fpel.check_sealed.call_args
+        assert call_args[0][0] == TASK_ID
+        assert "current_hash" in call_args[1], "check_sealed() MUST receive current_hash"
         repo.cas_save.assert_called_once()
 
     def test_start_blocks_candidate_verdict(self) -> None:

--- a/tests/unit/domain/test_fpel_content_hash.py
+++ b/tests/unit/domain/test_fpel_content_hash.py
@@ -1,0 +1,157 @@
+"""Tests for FPEL content hash computation at call sites.
+
+Verifies that:
+1. OrchestrationTask has a stable canonical hash
+2. PlanState has a stable canonical hash
+3. Changes to fields produce different hashes
+4. Same content produces same hash (idempotent)
+"""
+
+from src.application.services.workflow.state import PlanState, Task, WorkflowPhase
+from src.domain.entities.orchestration_task import (
+    OrchestrationTask,
+    OrchestrationTaskStatus,
+)
+from src.infrastructure.persistence.fpel_content_hash import (
+    compute_plan_hash,
+    compute_task_hash,
+)
+
+
+class TestComputeTaskHash:
+    """OrchestrationTask canonical hash computation."""
+
+    def test_stable_hash_same_task(self) -> None:
+        """Same task data always produces same hash."""
+        task = OrchestrationTask(
+            id="t-001",
+            subject="Add auth",
+            description="Implement JWT auth",
+            status=OrchestrationTaskStatus.APPROVED,
+            plan_text="# Plan\n1. Add middleware\n2. Add tests",
+        )
+        h1 = compute_task_hash(task)
+        h2 = compute_task_hash(task)
+        assert h1 == h2
+
+    def test_different_content_different_hash(self) -> None:
+        """Changed plan_text produces different hash."""
+        task_a = OrchestrationTask(
+            id="t-001",
+            subject="Add auth",
+            status=OrchestrationTaskStatus.APPROVED,
+            plan_text="# Plan A",
+        )
+        task_b = OrchestrationTask(
+            id="t-001",
+            subject="Add auth",
+            status=OrchestrationTaskStatus.APPROVED,
+            plan_text="# Plan B — CHANGED",
+        )
+        assert compute_task_hash(task_a) != compute_task_hash(task_b)
+
+    def test_post_freeze_drift_detected(self) -> None:
+        """If plan_text changes after freeze, hash drift is detected."""
+        task = OrchestrationTask(
+            id="t-001",
+            subject="Add auth",
+            status=OrchestrationTaskStatus.APPROVED,
+            plan_text="# Original plan",
+        )
+        frozen_hash = compute_task_hash(task)
+
+        # Simulate post-freeze change
+        from dataclasses import replace
+
+        modified = replace(task, plan_text="# Modified plan")
+        current_hash = compute_task_hash(modified)
+
+        assert frozen_hash != current_hash, "Drift MUST be detected"
+
+    def test_no_plan_text_uses_subject_and_description(self) -> None:
+        """When plan_text is None, hash uses subject + description."""
+        task = OrchestrationTask(
+            id="t-001",
+            subject="Add auth",
+            description="JWT middleware",
+            status=OrchestrationTaskStatus.APPROVED,
+        )
+        h = compute_task_hash(task)
+        assert isinstance(h, str)
+        assert len(h) == 64  # SHA-256 hex digest
+
+    def test_status_change_does_not_change_hash(self) -> None:
+        """Hash is content-based, not status-based."""
+        from dataclasses import replace
+
+        task = OrchestrationTask(
+            id="t-001",
+            subject="Add auth",
+            plan_text="# Plan",
+            status=OrchestrationTaskStatus.APPROVED,
+        )
+        h_approved = compute_task_hash(task)
+        task_in_progress = replace(task, status=OrchestrationTaskStatus.IN_PROGRESS)
+        h_in_progress = compute_task_hash(task_in_progress)
+        # Status change should NOT change hash — content hasn't changed
+        assert h_approved == h_in_progress
+
+
+class TestComputePlanHash:
+    """PlanState canonical hash computation."""
+
+    def test_stable_hash_same_plan(self) -> None:
+        """Same plan always produces same hash."""
+        plan = PlanState(
+            session_id="sess-001",
+            phase=WorkflowPhase.OUTLINED,
+            tasks=[
+                Task(id="t-001", slug="auth", description="Add JWT"),
+            ],
+        )
+        h1 = compute_plan_hash(plan)
+        h2 = compute_plan_hash(plan)
+        assert h1 == h2
+
+    def test_different_tasks_different_hash(self) -> None:
+        """Changed tasks produce different hash."""
+        plan_a = PlanState(
+            session_id="sess-001",
+            phase=WorkflowPhase.OUTLINED,
+            tasks=[Task(id="t-001", slug="auth", description="Add JWT")],
+        )
+        plan_b = PlanState(
+            session_id="sess-001",
+            phase=WorkflowPhase.OUTLINED,
+            tasks=[Task(id="t-001", slug="auth", description="Add OAuth")],
+        )
+        assert compute_plan_hash(plan_a) != compute_plan_hash(plan_b)
+
+    def test_post_freeze_drift_detected(self) -> None:
+        """If tasks change after freeze, hash drift is detected."""
+        plan = PlanState(
+            session_id="sess-001",
+            phase=WorkflowPhase.OUTLINED,
+            tasks=[Task(id="t-001", slug="auth", description="JWT")],
+        )
+        frozen_hash = compute_plan_hash(plan)
+
+        modified = PlanState(
+            session_id="sess-001",
+            phase=WorkflowPhase.OUTLINED,
+            tasks=[Task(id="t-001", slug="auth", description="JWT + OAuth")],
+        )
+        current_hash = compute_plan_hash(modified)
+
+        assert frozen_hash != current_hash, "Drift MUST be detected"
+
+    def test_empty_plan_stable_hash(self) -> None:
+        """Empty plan (no tasks) produces stable hash."""
+        plan = PlanState(
+            session_id="sess-empty",
+            phase=WorkflowPhase.PLANNING,
+            tasks=[],
+        )
+        h = compute_plan_hash(plan)
+        assert isinstance(h, str)
+        assert len(h) == 64

--- a/tests/unit/domain/test_fpel_content_hash.py
+++ b/tests/unit/domain/test_fpel_content_hash.py
@@ -1,21 +1,28 @@
-"""Tests for FPEL content hash computation at call sites.
+"""Tests for FPEL content hash computation — canonical hash functions.
 
 Verifies that:
 1. OrchestrationTask has a stable canonical hash
-2. PlanState has a stable canonical hash
-3. Changes to fields produce different hashes
-4. Same content produces same hash (idempotent)
+2. Plan task list has a stable canonical hash
+3. Single plan task hash is stable and scope-correct
+4. Changes to fields produce different hashes
+5. Same content produces same hash (idempotent)
 """
 
-from src.application.services.workflow.state import PlanState, Task, WorkflowPhase
+from dataclasses import replace
+
 from src.domain.entities.orchestration_task import (
     OrchestrationTask,
     OrchestrationTaskStatus,
 )
-from src.infrastructure.persistence.fpel_content_hash import (
-    compute_plan_hash,
+from src.domain.services.fpel_content_hash import (
+    compute_plan_hash_from_tasks,
+    compute_plan_task_hash,
     compute_task_hash,
 )
+
+
+def _task_dict(tid: str = "t-001", slug: str = "auth", desc: str = "Add JWT") -> dict[str, str]:
+    return {"id": tid, "slug": slug, "description": desc}
 
 
 class TestComputeTaskHash:
@@ -59,13 +66,8 @@ class TestComputeTaskHash:
             plan_text="# Original plan",
         )
         frozen_hash = compute_task_hash(task)
-
-        # Simulate post-freeze change
-        from dataclasses import replace
-
         modified = replace(task, plan_text="# Modified plan")
         current_hash = compute_task_hash(modified)
-
         assert frozen_hash != current_hash, "Drift MUST be detected"
 
     def test_no_plan_text_uses_subject_and_description(self) -> None:
@@ -82,8 +84,6 @@ class TestComputeTaskHash:
 
     def test_status_change_does_not_change_hash(self) -> None:
         """Hash is content-based, not status-based."""
-        from dataclasses import replace
-
         task = OrchestrationTask(
             id="t-001",
             subject="Add auth",
@@ -93,65 +93,49 @@ class TestComputeTaskHash:
         h_approved = compute_task_hash(task)
         task_in_progress = replace(task, status=OrchestrationTaskStatus.IN_PROGRESS)
         h_in_progress = compute_task_hash(task_in_progress)
-        # Status change should NOT change hash — content hasn't changed
         assert h_approved == h_in_progress
 
 
-class TestComputePlanHash:
-    """PlanState canonical hash computation."""
+class TestComputePlanHashFromTasks:
+    """Plan task-list canonical hash computation."""
 
-    def test_stable_hash_same_plan(self) -> None:
-        """Same plan always produces same hash."""
-        plan = PlanState(
-            session_id="sess-001",
-            phase=WorkflowPhase.OUTLINED,
-            tasks=[
-                Task(id="t-001", slug="auth", description="Add JWT"),
-            ],
-        )
-        h1 = compute_plan_hash(plan)
-        h2 = compute_plan_hash(plan)
+    def test_stable_hash_same_tasks(self) -> None:
+        h1 = compute_plan_hash_from_tasks([_task_dict()])
+        h2 = compute_plan_hash_from_tasks([_task_dict()])
         assert h1 == h2
 
     def test_different_tasks_different_hash(self) -> None:
-        """Changed tasks produce different hash."""
-        plan_a = PlanState(
-            session_id="sess-001",
-            phase=WorkflowPhase.OUTLINED,
-            tasks=[Task(id="t-001", slug="auth", description="Add JWT")],
-        )
-        plan_b = PlanState(
-            session_id="sess-001",
-            phase=WorkflowPhase.OUTLINED,
-            tasks=[Task(id="t-001", slug="auth", description="Add OAuth")],
-        )
-        assert compute_plan_hash(plan_a) != compute_plan_hash(plan_b)
+        ha = compute_plan_hash_from_tasks([_task_dict(desc="Add JWT")])
+        hb = compute_plan_hash_from_tasks([_task_dict(desc="Add OAuth")])
+        assert ha != hb
 
     def test_post_freeze_drift_detected(self) -> None:
-        """If tasks change after freeze, hash drift is detected."""
-        plan = PlanState(
-            session_id="sess-001",
-            phase=WorkflowPhase.OUTLINED,
-            tasks=[Task(id="t-001", slug="auth", description="JWT")],
-        )
-        frozen_hash = compute_plan_hash(plan)
-
-        modified = PlanState(
-            session_id="sess-001",
-            phase=WorkflowPhase.OUTLINED,
-            tasks=[Task(id="t-001", slug="auth", description="JWT + OAuth")],
-        )
-        current_hash = compute_plan_hash(modified)
-
-        assert frozen_hash != current_hash, "Drift MUST be detected"
+        frozen = compute_plan_hash_from_tasks([_task_dict(desc="JWT")])
+        current = compute_plan_hash_from_tasks([_task_dict(desc="JWT + OAuth")])
+        assert frozen != current, "Drift MUST be detected"
 
     def test_empty_plan_stable_hash(self) -> None:
-        """Empty plan (no tasks) produces stable hash."""
-        plan = PlanState(
-            session_id="sess-empty",
-            phase=WorkflowPhase.PLANNING,
-            tasks=[],
-        )
-        h = compute_plan_hash(plan)
+        h = compute_plan_hash_from_tasks([])
         assert isinstance(h, str)
         assert len(h) == 64
+
+
+class TestComputePlanTaskHash:
+    """Single plan task hash — used for task-scoped targets."""
+
+    def test_stable_hash(self) -> None:
+        h1 = compute_plan_task_hash("t-1", "auth", "Add JWT")
+        h2 = compute_plan_task_hash("t-1", "auth", "Add JWT")
+        assert h1 == h2
+
+    def test_different_description_different_hash(self) -> None:
+        ha = compute_plan_task_hash("t-1", "auth", "JWT")
+        hb = compute_plan_task_hash("t-1", "auth", "OAuth")
+        assert ha != hb
+
+    def test_task_hash_differs_from_plan_hash(self) -> None:
+        """Task-level hash ≠ plan-level hash (different scope)."""
+        td = _task_dict()
+        task_hash = compute_plan_task_hash(td["id"], td["slug"], td["description"])
+        plan_hash = compute_plan_hash_from_tasks([td])
+        assert task_hash != plan_hash, "Task hash MUST differ from plan hash (scope isolation)"

--- a/tests/unit/interfaces/cli/commands/test_workflow.py
+++ b/tests/unit/interfaces/cli/commands/test_workflow.py
@@ -655,7 +655,7 @@ class TestWorkflowExecuteHashAuthority:
 
     def test_execute_passes_plan_hash_to_gate(self, tmp_path: Path) -> None:
         """workflow execute MUST compute and pass current_hash from plan."""
-        from src.infrastructure.persistence.fpel_content_hash import compute_plan_hash
+        from src.domain.services.fpel_content_hash import compute_plan_hash_from_tasks
 
         plan_state = PlanState(
             session_id="hash-auth-test",
@@ -712,7 +712,10 @@ class TestWorkflowExecuteHashAuthority:
         assert result.exit_code == 0
         call_kwargs = mock_fpel_port.check_sealed.call_args[1]
         assert "current_hash" in call_kwargs
-        assert call_kwargs["current_hash"] == compute_plan_hash(plan_state)
+        expected_hash = compute_plan_hash_from_tasks(
+            [{"id": t.id, "slug": t.slug, "description": t.description} for t in plan_state.tasks]
+        )
+        assert call_kwargs["current_hash"] == expected_hash
 
     def test_execute_post_freeze_task_change_blocks(self, tmp_path: Path) -> None:
         """If tasks change after freeze, execute blocked by HASH_MISMATCH.
@@ -764,6 +767,122 @@ class TestWorkflowExecuteHashAuthority:
 
         assert result.exit_code != 0
         mock_executor.execute_plan.assert_not_called()
+
+
+class TestWorkflowExecuteTaskScopedHash:
+    """Verify task-scoped hash when execute is called with task_id."""
+
+    def test_execute_with_task_id_uses_task_hash_not_plan_hash(self, tmp_path: Path) -> None:
+        """When task_id provided, current_hash must be task-level, not plan-level."""
+        from src.domain.services.fpel_content_hash import (
+            compute_plan_hash_from_tasks,
+            compute_plan_task_hash,
+        )
+
+        plan_state = PlanState(
+            session_id="scope-test",
+            phase=WorkflowPhase.OUTLINED,
+            tasks=[
+                Task(id="t-1", slug="auth", description="Add JWT"),
+                Task(id="t-2", slug="db", description="Add migrations"),
+            ],
+        )
+        plan_path = tmp_path / "plan-state.json"
+        plan_state.save(plan_path)
+
+        sealed_decision = AuthorizationDecision(
+            allowed=True,
+            status=FPELStatus.SEALED_PASS,
+            frozen_proposal_id="fp-1",
+            content_hash="abc123",
+            reason=None,
+            seal_id="seal-1",
+            sealed_at=datetime.now(UTC),
+        )
+        mock_fpel_port = MagicMock()
+        mock_fpel_port.check_sealed.return_value = sealed_decision
+
+        executor_result = MagicMock()
+        exec_state = ExecuteState(
+            session_id="scope-exec",
+            phase=WorkflowPhase.EXECUTING,
+            tasks=plan_state.tasks,
+        )
+        executor_result.exec_state = exec_state
+        executor_result.spawned_sessions = []
+        executor_result.errors = []
+        mock_executor = MagicMock()
+        mock_executor.execute_plan.return_value = executor_result
+
+        with (
+            patch(
+                "src.interfaces.cli.commands.workflow.get_plan_state_path",
+                return_value=plan_path,
+            ),
+            patch(
+                "src.interfaces.cli.commands.workflow.get_execute_state_path",
+                return_value=tmp_path / "execute-state.json",
+            ),
+            patch(
+                "src.interfaces.cli.dependencies.get_workflow_executor",
+                return_value=mock_executor,
+            ),
+            patch(
+                "src.interfaces.cli.commands.workflow.get_fpel_authorization_port",
+                return_value=mock_fpel_port,
+            ),
+        ):
+            result = runner.invoke(get_app(), ["execute", "t-1"])
+
+        assert result.exit_code == 0
+        call_kwargs = mock_fpel_port.check_sealed.call_args[1]
+        actual_hash = call_kwargs["current_hash"]
+
+        # Must be task-scoped hash, NOT plan-level hash
+        task_hash = compute_plan_task_hash("t-1", "auth", "Add JWT")
+        plan_hash = compute_plan_hash_from_tasks(
+            [{"id": t.id, "slug": t.slug, "description": t.description} for t in plan_state.tasks]
+        )
+        assert actual_hash == task_hash, (
+            f"Expected task hash {task_hash[:16]}, got {actual_hash[:16]}"
+        )
+        assert actual_hash != plan_hash, "Must NOT be plan-level hash"
+
+    def test_execute_task_id_not_found_in_plan(self, tmp_path: Path) -> None:
+        """When task_id not in plan.tasks, execute must exit with error."""
+        plan_state = PlanState(
+            session_id="not-found-test",
+            phase=WorkflowPhase.OUTLINED,
+            tasks=[Task(id="t-1", slug="auth", description="Add JWT")],
+        )
+        plan_path = tmp_path / "plan-state.json"
+        plan_state.save(plan_path)
+
+        mock_fpel_port = MagicMock()
+        mock_executor = MagicMock()
+
+        with (
+            patch(
+                "src.interfaces.cli.commands.workflow.get_plan_state_path",
+                return_value=plan_path,
+            ),
+            patch(
+                "src.interfaces.cli.commands.workflow.get_execute_state_path",
+                return_value=tmp_path / "execute-state.json",
+            ),
+            patch(
+                "src.interfaces.cli.dependencies.get_workflow_executor",
+                return_value=mock_executor,
+            ),
+            patch(
+                "src.interfaces.cli.commands.workflow.get_fpel_authorization_port",
+                return_value=mock_fpel_port,
+            ),
+        ):
+            result = runner.invoke(get_app(), ["execute", "nonexistent-task"])
+
+        assert result.exit_code != 0
+        mock_fpel_port.check_sealed.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/interfaces/cli/commands/test_workflow.py
+++ b/tests/unit/interfaces/cli/commands/test_workflow.py
@@ -650,6 +650,122 @@ class TestWorkflowExecuteFPELGate:
         assert "HASH_MISMATCH" in result.output or "sealed PASS" in result.output
 
 
+class TestWorkflowExecuteHashAuthority:
+    """Verify that workflow execute passes current_hash to check_sealed()."""
+
+    def test_execute_passes_plan_hash_to_gate(self, tmp_path: Path) -> None:
+        """workflow execute MUST compute and pass current_hash from plan."""
+        from src.infrastructure.persistence.fpel_content_hash import compute_plan_hash
+
+        plan_state = PlanState(
+            session_id="hash-auth-test",
+            phase=WorkflowPhase.OUTLINED,
+            tasks=[Task(id="t-1", slug="auth", description="Add JWT auth")],
+        )
+        plan_path = tmp_path / "plan-state.json"
+        plan_state.save(plan_path)
+
+        sealed_decision = AuthorizationDecision(
+            allowed=True,
+            status=FPELStatus.SEALED_PASS,
+            frozen_proposal_id="fp-1",
+            content_hash="abc123",
+            reason=None,
+            seal_id="seal-1",
+            sealed_at=datetime.now(UTC),
+        )
+        mock_fpel_port = MagicMock()
+        mock_fpel_port.check_sealed.return_value = sealed_decision
+
+        executor_result = MagicMock()
+        exec_state = ExecuteState(
+            session_id="hash-auth-exec",
+            phase=WorkflowPhase.EXECUTING,
+            tasks=plan_state.tasks,
+        )
+        executor_result.exec_state = exec_state
+        executor_result.spawned_sessions = []
+        executor_result.errors = []
+        mock_executor = MagicMock()
+        mock_executor.execute_plan.return_value = executor_result
+
+        with (
+            patch(
+                "src.interfaces.cli.commands.workflow.get_plan_state_path",
+                return_value=plan_path,
+            ),
+            patch(
+                "src.interfaces.cli.commands.workflow.get_execute_state_path",
+                return_value=tmp_path / "execute-state.json",
+            ),
+            patch(
+                "src.interfaces.cli.dependencies.get_workflow_executor",
+                return_value=mock_executor,
+            ),
+            patch(
+                "src.interfaces.cli.commands.workflow.get_fpel_authorization_port",
+                return_value=mock_fpel_port,
+            ),
+        ):
+            result = runner.invoke(get_app(), ["execute"])
+
+        assert result.exit_code == 0
+        call_kwargs = mock_fpel_port.check_sealed.call_args[1]
+        assert "current_hash" in call_kwargs
+        assert call_kwargs["current_hash"] == compute_plan_hash(plan_state)
+
+    def test_execute_post_freeze_task_change_blocks(self, tmp_path: Path) -> None:
+        """If tasks change after freeze, execute blocked by HASH_MISMATCH.
+
+        Demonstrates: plan frozen with tasks=[t-1: JWT], then tasks changed
+        to tasks=[t-1: OAuth]. The gate detects drift via current_hash.
+        """
+        plan_state = PlanState(
+            session_id="drift-test",
+            phase=WorkflowPhase.OUTLINED,
+            tasks=[Task(id="t-1", slug="auth", description="Add OAuth")],
+        )
+        plan_path = tmp_path / "plan-state.json"
+        plan_state.save(plan_path)
+
+        drift_decision = AuthorizationDecision(
+            allowed=False,
+            status=FPELStatus.SEALED_PASS,
+            frozen_proposal_id="fp-1",
+            content_hash="original-hash",
+            reason=SealFailureReason.HASH_MISMATCH,
+            seal_id=None,
+            sealed_at=None,
+        )
+        mock_fpel_port = MagicMock()
+        mock_fpel_port.check_sealed.return_value = drift_decision
+
+        mock_executor = MagicMock()
+
+        with (
+            patch(
+                "src.interfaces.cli.commands.workflow.get_plan_state_path",
+                return_value=plan_path,
+            ),
+            patch(
+                "src.interfaces.cli.commands.workflow.get_execute_state_path",
+                return_value=tmp_path / "execute-state.json",
+            ),
+            patch(
+                "src.interfaces.cli.dependencies.get_workflow_executor",
+                return_value=mock_executor,
+            ),
+            patch(
+                "src.interfaces.cli.commands.workflow.get_fpel_authorization_port",
+                return_value=mock_fpel_port,
+            ),
+        ):
+            result = runner.invoke(get_app(), ["execute"])
+
+        assert result.exit_code != 0
+        mock_executor.execute_plan.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # Phase 1 RED: FPEL Runtime Wiring — fail-closed + target_id namespace
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## FPEL Hash Authority

Closes #44

Wire `current_hash` from call sites (`TaskBoardService.start()`, `workflow execute`) to `FPELAuthorizationPort.check_sealed()`, eliminating the self-referential repository fallback for drift detection.

### What Changed

**New module**: `src/infrastructure/persistence/fpel_content_hash.py`
- `compute_task_hash(task)` — canonical SHA-256 of `OrchestrationTask` content (plan_text, or subject+description fallback)
- `compute_plan_hash(plan)` — canonical SHA-256 of `PlanState` task list (id + slug + description)

**Call sites wired**:
- `TaskBoardService.start()` → computes task hash, passes `current_hash=...` to `check_sealed()`
- `workflow execute` → computes plan hash, passes `current_hash=...` to `check_sealed()`

**Hash scope**: Content fields only (plan_text, subject, description, task definitions). Excludes lifecycle metadata (status, owner, timestamps) to avoid false positives on valid state transitions.

### How Drift Detection Works

```
Freeze time:  compute_task_hash(task) → hash_h1 → stored in FrozenProposal
Execute time: compute_task_hash(task) → hash_h2 → passed to check_sealed()
check_sealed: hash_h1 == hash_h2? → YES: PASS | NO: HASH_MISMATCH
```

Post-freeze changes to `plan_text` or task definitions produce a different hash → gate blocks with `HASH_MISMATCH`.

### Tests (+13 new)

- 9 content hash computation tests (stability, drift, idempotency for task + plan)
- 2 TaskBoardService tests (passes current_hash, post-freeze change blocks start)
- 2 workflow execute tests (passes current_hash, post-freeze change blocks execute)

**Total: 2692 passed, 0 failures**

### CI

- `ruff check` ✅
- `ruff format` ✅
- `mypy` ✅
- `pytest` 2692/0 ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new CLI options for freezing proposals directly from task or plan sources
  * Content-based security validation now integrated into authorization checks for proposals
  * Improved data integrity verification through deterministic hashing of plans and tasks

* **Improvements**
  * Enhanced proposal freezing process with support for multiple input modes
  * Authorization system now validates against computed content hashes during execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->