### PR TITLE
feat(fpel): add legacy APPROVED snapshot creation

### DIFF
--- a/src/application/services/fpel_authorization_service.py
+++ b/src/application/services/fpel_authorization_service.py
@@ -404,3 +404,98 @@ class FPELAuthorizationService:
             seal_id=None,
             sealed_at=None,
         )
+
+    def snapshot_legacy(self, target_id: str, content: str) -> tuple[FrozenProposal, SealedVerdict]:
+        """Create a legacy-approved snapshot: freeze + seal with source='LEGACY_APPROVED'.
+
+        Uses ``compute_content_hash(content)`` — NOT hash-authority compliant.
+        Use ``snapshot_legacy_task`` or ``snapshot_legacy_plan`` for hash authority.
+        Bypasses checker requirements — directly seals.
+        Idempotent: returns existing if sealed verdict already exists.
+        Raises ValueError if target has a failed proposal.
+        """
+        content_hash = compute_content_hash(content)
+        return self._snapshot_legacy_inner(target_id, content, content_hash)
+
+    def snapshot_legacy_task(
+        self,
+        target_id: str,
+        plan_text: str | None,
+        subject: str,
+        description: str | None = None,
+    ) -> tuple[FrozenProposal, SealedVerdict]:
+        """Legacy snapshot using canonical task hash authority.
+
+        Computes the same hash as ``compute_task_hash()`` so that
+        ``check_sealed(current_hash=compute_task_hash(task))`` passes.
+        """
+        content = plan_text
+        if content is None:
+            parts = [subject]
+            if description:
+                parts.append(description)
+            content = "\n".join(parts)
+        content_hash = compute_content_hash(content)
+        return self._snapshot_legacy_inner(target_id, content, content_hash)
+
+    def snapshot_legacy_plan(
+        self, target_id: str, tasks: list[dict[str, str]]
+    ) -> tuple[FrozenProposal, SealedVerdict]:
+        """Legacy snapshot using canonical plan hash authority.
+
+        Computes the same hash as ``compute_plan_hash_from_tasks()`` so that
+        ``check_sealed(current_hash=compute_plan_hash(...))`` passes.
+
+        Args:
+            target_id: The plan session ID.
+            tasks: List of dicts with id/slug/description keys.
+        """
+        import json
+
+        task_data = [
+            {"id": t["id"], "slug": t["slug"], "description": t["description"]} for t in tasks
+        ]
+        canonical = json.dumps(task_data, sort_keys=True, separators=(",", ":"))
+        content_hash = compute_content_hash(canonical)
+        return self._snapshot_legacy_inner(target_id, canonical, content_hash)
+
+    def _snapshot_legacy_inner(
+        self, target_id: str, content: str, content_hash: str
+    ) -> tuple[FrozenProposal, SealedVerdict]:
+        """Shared logic for all snapshot_legacy variants.
+
+        Checks FAIL guard and idempotency, then atomically persists
+        frozen proposal + sealed verdict.
+        """
+        frozen = self._repo.get_active_frozen_proposal(target_id)
+
+        if frozen is not None:
+            if self._repo.is_failed(frozen.frozen_proposal_id):
+                raise ValueError(
+                    f"Cannot snapshot legacy for target '{target_id}': proposal already failed"
+                )
+            sealed = self._repo.get_sealed_verdict(frozen.frozen_proposal_id)
+            if sealed is not None:
+                return frozen, sealed
+
+        existing = self._repo.get_all_frozen_proposals(target_id)
+        for old_fp in existing:
+            if old_fp.is_active:
+                self._repo.mark_superseded(old_fp.frozen_proposal_id)
+
+        frozen_id = f"fp-{uuid.uuid4().hex[:12]}"
+        proposal = FrozenProposal(
+            frozen_proposal_id=frozen_id,
+            target_id=target_id,
+            content_hash=content_hash,
+            content=content,
+        )
+        sealed = SealedVerdict(
+            frozen_proposal_id=frozen_id,
+            verdict="SEALED_PASS",
+            sealed_at=datetime.now(tz=UTC),
+            content_hash=content_hash,
+            source="LEGACY_APPROVED",
+        )
+        self._repo.save_frozen_with_sealed_verdict(proposal, sealed)
+        return proposal, sealed

--- a/src/application/services/fpel_authorization_service.py
+++ b/src/application/services/fpel_authorization_service.py
@@ -137,13 +137,12 @@ class FPELAuthorizationService:
     def freeze(self, target_id: str, content: str) -> FrozenProposal:
         """Create an immutable frozen snapshot of the proposal content.
 
-        Any existing frozen proposals for this target are marked SUPERSEDED.
+        Any existing frozen proposals for this target are marked SUPERSEDED
+        atomically within the same save operation.
         """
-        # Supersede all previous frozen proposals for this target
+        # Collect active proposal IDs for atomic supersede
         existing = self._repo.get_all_frozen_proposals(target_id)
-        for old_fp in existing:
-            if old_fp.is_active:
-                self._repo.mark_superseded(old_fp.frozen_proposal_id)
+        supersede_ids = [fp.frozen_proposal_id for fp in existing if fp.is_active]
 
         content_hash = compute_content_hash(content)
         frozen_id = f"fp-{uuid.uuid4().hex[:12]}"
@@ -154,7 +153,7 @@ class FPELAuthorizationService:
             content_hash=content_hash,
             content=content,
         )
-        self._repo.save_frozen_proposal(proposal)
+        self._repo.save_frozen_proposal(proposal, supersede_ids=supersede_ids)
         return proposal
 
     def freeze_task(
@@ -477,11 +476,13 @@ class FPELAuthorizationService:
             sealed = self._repo.get_sealed_verdict(frozen.frozen_proposal_id)
             if sealed is not None:
                 return frozen, sealed
+            raise ValueError(
+                f"Cannot snapshot legacy for target '{target_id}': "
+                f"active unsealed proposal exists (run 'fpel fail' first)"
+            )
 
         existing = self._repo.get_all_frozen_proposals(target_id)
-        for old_fp in existing:
-            if old_fp.is_active:
-                self._repo.mark_superseded(old_fp.frozen_proposal_id)
+        supersede_ids = [fp.frozen_proposal_id for fp in existing if fp.is_active]
 
         frozen_id = f"fp-{uuid.uuid4().hex[:12]}"
         proposal = FrozenProposal(
@@ -497,5 +498,5 @@ class FPELAuthorizationService:
             content_hash=content_hash,
             source="LEGACY_APPROVED",
         )
-        self._repo.save_frozen_with_sealed_verdict(proposal, sealed)
+        self._repo.save_frozen_with_sealed_verdict(proposal, sealed, supersede_ids=supersede_ids)
         return proposal, sealed

--- a/src/domain/entities/fpel.py
+++ b/src/domain/entities/fpel.py
@@ -137,12 +137,14 @@ class SealedVerdict:
         verdict: Always "SEALED_PASS".
         sealed_at: Timestamp when sealing occurred.
         content_hash: Hash of the content at seal time.
+        source: Origin of the seal (e.g. 'LEGACY_APPROVED'), None for normal seal flow.
     """
 
     frozen_proposal_id: str
     verdict: str
     sealed_at: datetime
     content_hash: str
+    source: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/domain/entities/fpel.py
+++ b/src/domain/entities/fpel.py
@@ -16,6 +16,7 @@ import json
 from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
+from typing import ClassVar
 
 # ---------------------------------------------------------------------------
 # Enums
@@ -145,6 +146,23 @@ class SealedVerdict:
     sealed_at: datetime
     content_hash: str
     source: str | None = None
+
+    _VALID_SOURCES: ClassVar[frozenset[str]] = frozenset(
+        {"LEGACY_APPROVED", "MANUAL_OVERRIDE", "AUTO_SEAL"}
+    )
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.frozen_proposal_id, str) or not self.frozen_proposal_id:
+            raise ValueError("frozen_proposal_id must be a non-empty string")
+        if self.verdict != "SEALED_PASS":
+            raise ValueError(f"verdict must be 'SEALED_PASS', got '{self.verdict}'")
+        if not isinstance(self.content_hash, str) or not self.content_hash:
+            raise ValueError("content_hash must be a non-empty string")
+        if self.source is not None and self.source not in self._VALID_SOURCES:
+            raise ValueError(
+                f"SealedVerdict.source must be one of {sorted(self._VALID_SOURCES)} "
+                f"or None, got '{self.source}'"
+            )
 
 
 @dataclass(frozen=True)

--- a/src/domain/ports/fpel_repository.py
+++ b/src/domain/ports/fpel_repository.py
@@ -72,3 +72,9 @@ class FPELRepository(Protocol):
     def is_failed(self, frozen_proposal_id: str) -> bool:
         """Single PK lookup — returns True if proposal has FAIL marker."""
         ...
+
+    def save_frozen_with_sealed_verdict(
+        self, proposal: FrozenProposal, verdict: SealedVerdict
+    ) -> None:
+        """Atomic: persist frozen proposal + sealed verdict in one transaction."""
+        ...

--- a/src/domain/ports/fpel_repository.py
+++ b/src/domain/ports/fpel_repository.py
@@ -5,6 +5,7 @@ Infrastructure layer implements this protocol against SQLite.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Protocol, runtime_checkable
 
 from src.domain.entities.fpel import FrozenProposal, SealedVerdict
@@ -22,8 +23,15 @@ class FPELRepository(Protocol):
         """Return all frozen proposals (including SUPERSEDED) for target."""
         ...
 
-    def save_frozen_proposal(self, proposal: FrozenProposal) -> None:
-        """Persist a new frozen proposal."""
+    def save_frozen_proposal(
+        self, proposal: FrozenProposal, supersede_ids: Sequence[str] = ()
+    ) -> None:
+        """Persist a new frozen proposal.
+
+        Args:
+            proposal: The frozen proposal to persist.
+            supersede_ids: IDs of existing proposals to mark SUPERSEDED atomically.
+        """
         ...
 
     def mark_superseded(self, frozen_proposal_id: str) -> None:
@@ -74,7 +82,16 @@ class FPELRepository(Protocol):
         ...
 
     def save_frozen_with_sealed_verdict(
-        self, proposal: FrozenProposal, verdict: SealedVerdict
+        self,
+        proposal: FrozenProposal,
+        verdict: SealedVerdict,
+        supersede_ids: Sequence[str] = (),
     ) -> None:
-        """Atomic: persist frozen proposal + sealed verdict in one transaction."""
+        """Atomic: persist frozen proposal + sealed verdict in one transaction.
+
+        Args:
+            proposal: The frozen proposal to persist.
+            verdict: The sealed verdict to persist.
+            supersede_ids: IDs of existing proposals to mark SUPERSEDED atomically.
+        """
         ...

--- a/src/infrastructure/persistence/migrations/036_add_sealed_verdict_source.sql
+++ b/src/infrastructure/persistence/migrations/036_add_sealed_verdict_source.sql
@@ -1,0 +1,4 @@
+-- 036_add_sealed_verdict_source.sql
+-- Add optional source column to sealed_verdicts for tracking seal origin (e.g. LEGACY_APPROVED).
+
+ALTER TABLE sealed_verdicts ADD COLUMN source TEXT;

--- a/src/infrastructure/persistence/repositories/fpel_repository.py
+++ b/src/infrastructure/persistence/repositories/fpel_repository.py
@@ -10,6 +10,7 @@ Implements the FPELRepository protocol against SQLite with:
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Any
 
 from src.domain.entities.fpel import (
     FrozenProposal,
@@ -17,6 +18,14 @@ from src.domain.entities.fpel import (
     SealedVerdict,
 )
 from src.infrastructure.persistence.database import DatabaseConnection
+
+
+def _row_source(row: Any) -> str | None:
+    try:
+        val = row["source"]
+        return str(val) if val is not None else None
+    except (IndexError, KeyError):
+        return None
 
 
 class SqliteFPELRepository:
@@ -97,7 +106,7 @@ class SqliteFPELRepository:
         """Return the sealed verdict for a frozen proposal, if any."""
         with self._connection as conn:
             cursor = conn.execute(
-                "SELECT frozen_proposal_id, verdict, sealed_at, content_hash "
+                "SELECT frozen_proposal_id, verdict, sealed_at, content_hash, source "
                 "FROM sealed_verdicts "
                 "WHERE frozen_proposal_id = ?",
                 (frozen_proposal_id,),
@@ -110,19 +119,21 @@ class SqliteFPELRepository:
             verdict=row["verdict"],
             sealed_at=datetime.fromisoformat(row["sealed_at"]),
             content_hash=row["content_hash"],
+            source=_row_source(row),
         )
 
     def save_sealed_verdict(self, verdict: SealedVerdict) -> None:
         """Persist a sealed verdict."""
         with self._connection as conn:
             conn.execute(
-                "INSERT INTO sealed_verdicts (frozen_proposal_id, verdict, sealed_at, content_hash) "
-                "VALUES (?, ?, ?, ?)",
+                "INSERT INTO sealed_verdicts (frozen_proposal_id, verdict, sealed_at, content_hash, source) "
+                "VALUES (?, ?, ?, ?, ?)",
                 (
                     verdict.frozen_proposal_id,
                     verdict.verdict,
                     verdict.sealed_at.isoformat(),
                     verdict.content_hash,
+                    verdict.source,
                 ),
             )
 
@@ -218,3 +229,31 @@ class SqliteFPELRepository:
                 (frozen_proposal_id,),
             )
             return cursor.fetchone() is not None
+
+    def save_frozen_with_sealed_verdict(
+        self, proposal: FrozenProposal, verdict: SealedVerdict
+    ) -> None:
+        """Atomic: persist frozen proposal + sealed verdict in one transaction."""
+        with self._connection as conn:
+            conn.execute(
+                "INSERT INTO frozen_proposals (frozen_proposal_id, target_id, content_hash, content, lifecycle) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (
+                    proposal.frozen_proposal_id,
+                    proposal.target_id,
+                    proposal.content_hash,
+                    proposal.content,
+                    proposal.lifecycle.value,
+                ),
+            )
+            conn.execute(
+                "INSERT INTO sealed_verdicts (frozen_proposal_id, verdict, sealed_at, content_hash, source) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (
+                    verdict.frozen_proposal_id,
+                    verdict.verdict,
+                    verdict.sealed_at.isoformat(),
+                    verdict.content_hash,
+                    verdict.source,
+                ),
+            )

--- a/src/infrastructure/persistence/repositories/fpel_repository.py
+++ b/src/infrastructure/persistence/repositories/fpel_repository.py
@@ -5,10 +5,12 @@ Implements the FPELRepository protocol against SQLite with:
 - Sealed verdict persistence with UNIQUE constraint enforcement
 - Checker reports and candidate verdicts
 - FPEL status tracking per target
+- Atomic supersede+save to eliminate TOCTOU windows
 """
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import datetime
 from typing import Any
 
@@ -79,9 +81,18 @@ class SqliteFPELRepository:
             for row in rows
         ]
 
-    def save_frozen_proposal(self, proposal: FrozenProposal) -> None:
-        """Persist a new frozen proposal."""
+    def save_frozen_proposal(
+        self, proposal: FrozenProposal, supersede_ids: Sequence[str] = ()
+    ) -> None:
+        """Persist a new frozen proposal, atomically superseding existing ones."""
         with self._connection as conn:
+            if supersede_ids:
+                placeholders = ",".join("?" * len(supersede_ids))
+                conn.execute(
+                    f"UPDATE frozen_proposals SET lifecycle = 'SUPERSEDED' "
+                    f"WHERE frozen_proposal_id IN ({placeholders})",
+                    tuple(supersede_ids),
+                )
             conn.execute(
                 "INSERT INTO frozen_proposals (frozen_proposal_id, target_id, content_hash, content, lifecycle) "
                 "VALUES (?, ?, ?, ?, ?)",
@@ -95,7 +106,13 @@ class SqliteFPELRepository:
             )
 
     def mark_superseded(self, frozen_proposal_id: str) -> None:
-        """Mark a frozen proposal as SUPERSEDED (terminal at proposal level)."""
+        """Mark a frozen proposal as SUPERSEDED (terminal at proposal level).
+
+        .. deprecated::
+            Use ``supersede_ids`` parameter on ``save_frozen_proposal`` or
+            ``save_frozen_with_sealed_verdict`` for atomic supersede+save.
+            This standalone method will be removed in a future version.
+        """
         with self._connection as conn:
             conn.execute(
                 "UPDATE frozen_proposals SET lifecycle = 'SUPERSEDED' WHERE frozen_proposal_id = ?",
@@ -231,10 +248,24 @@ class SqliteFPELRepository:
             return cursor.fetchone() is not None
 
     def save_frozen_with_sealed_verdict(
-        self, proposal: FrozenProposal, verdict: SealedVerdict
+        self,
+        proposal: FrozenProposal,
+        verdict: SealedVerdict,
+        supersede_ids: Sequence[str] = (),
     ) -> None:
-        """Atomic: persist frozen proposal + sealed verdict in one transaction."""
+        """Atomic: persist frozen proposal + sealed verdict in one transaction.
+
+        When ``supersede_ids`` is non-empty, marks those proposals SUPERSEDED
+        before inserting the new ones — all in the same ``with conn`` block.
+        """
         with self._connection as conn:
+            if supersede_ids:
+                placeholders = ",".join("?" * len(supersede_ids))
+                conn.execute(
+                    f"UPDATE frozen_proposals SET lifecycle = 'SUPERSEDED' "
+                    f"WHERE frozen_proposal_id IN ({placeholders})",
+                    tuple(supersede_ids),
+                )
             conn.execute(
                 "INSERT INTO frozen_proposals (frozen_proposal_id, target_id, content_hash, content, lifecycle) "
                 "VALUES (?, ?, ?, ?, ?)",

--- a/src/interfaces/cli/commands/fpel.py
+++ b/src/interfaces/cli/commands/fpel.py
@@ -202,3 +202,97 @@ def fail_proposal(
     console.print(f"  frozen_proposal_id: {frozen.frozen_proposal_id}")
     if reason:
         console.print(f"  reason:             {reason}")
+
+
+@app.command("snapshot-legacy")
+def snapshot_legacy(
+    target_id: Annotated[str, typer.Option("--target-id", help="Target ID for legacy snapshot")],
+    content: Annotated[
+        str | None,
+        typer.Option(
+            "--content",
+            help="Raw content (low-level, NOT hash-authority compliant)",
+        ),
+    ] = None,
+    from_task: Annotated[
+        str | None,
+        typer.Option("--from-task", help="Task ID — snapshot with canonical task hash authority"),
+    ] = None,
+    from_plan: Annotated[
+        str | None,
+        typer.Option(
+            "--from-plan", help="Plan session ID — snapshot with canonical plan hash authority"
+        ),
+    ] = None,
+) -> None:
+    """Create a legacy-approved snapshot (freeze + seal with source=LEGACY_APPROVED).
+
+    Use --from-task or --from-plan for hash-authority compliant snapshot
+    (canonical hash matches what check_sealed() computes at runtime).
+    Use --content for low-level/arbitrary content (NOT hash-authority compliant).
+    """
+    sources = [content is not None, from_task is not None, from_plan is not None]
+    if sum(sources) != 1:
+        console.print(
+            "[red]Error: Provide exactly one of --content, --from-task, --from-plan[/red]"
+        )
+        raise typer.Exit(1)
+
+    service = _require_fpel_service()
+
+    try:
+        if content is not None:
+            console.print(
+                "[yellow]Warning: --content is NOT hash-authority compliant. "
+                "Post-snapshot runtime checks may produce HASH_MISMATCH. "
+                "Use --from-task or --from-plan for authority.[/yellow]"
+            )
+            frozen, sealed = service.snapshot_legacy(target_id=target_id, content=content)
+        elif from_task is not None:
+            from src.infrastructure.persistence.container import get_container
+
+            container = get_container()
+            task_board = container.task_board_service()
+            task = task_board.get(from_task)
+            if task is None:
+                console.print(f"[red]Error: Task '{from_task}' not found[/red]")
+                raise typer.Exit(1)
+            frozen, sealed = service.snapshot_legacy_task(
+                target_id=target_id,
+                plan_text=task.plan_text,
+                subject=task.subject,
+                description=task.description,
+            )
+        else:
+            from src.interfaces.cli.commands.workflow import get_plan_state_path
+
+            plan_path = get_plan_state_path()
+            if not plan_path.exists():
+                console.print(
+                    "[red]Error: No plan state found. Run 'workflow outline' first.[/red]"
+                )
+                raise typer.Exit(1)
+            from src.application.services.workflow.state import PlanState
+
+            plan = PlanState.load(plan_path)
+            if plan is None:
+                console.print("[red]Error: Failed to load plan state.[/red]")
+                raise typer.Exit(1)
+            if plan.session_id != from_plan:
+                console.print(
+                    f"[red]Error: Plan session_id '{plan.session_id}' does not match --from-plan '{from_plan}'[/red]"
+                )
+                raise typer.Exit(1)
+            tasks_data = [
+                {"id": t.id, "slug": t.slug, "description": t.description} for t in plan.tasks
+            ]
+            frozen, sealed = service.snapshot_legacy_plan(target_id=target_id, tasks=tasks_data)
+    except ValueError as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        raise typer.Exit(12) from exc
+
+    console.print("[green]Legacy snapshot created.[/green]")
+    console.print(f"  frozen_proposal_id: {frozen.frozen_proposal_id}")
+    console.print(f"  verdict:            {sealed.verdict}")
+    console.print(f"  source:             {sealed.source}")
+    console.print(f"  content_hash:       {sealed.content_hash[:16]}...")

--- a/src/interfaces/cli/commands/fpel.py
+++ b/src/interfaces/cli/commands/fpel.py
@@ -288,7 +288,10 @@ def snapshot_legacy(
             ]
             frozen, sealed = service.snapshot_legacy_plan(target_id=target_id, tasks=tasks_data)
     except ValueError as exc:
+        msg = str(exc)
         console.print(f"[red]Error: {exc}[/red]")
+        if "active unsealed" in msg:
+            raise typer.Exit(13) from exc
         raise typer.Exit(12) from exc
 
     console.print("[green]Legacy snapshot created.[/green]")

--- a/tests/integration/test_fpel_legacy_snapshot_roundtrip.py
+++ b/tests/integration/test_fpel_legacy_snapshot_roundtrip.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.application.services.fpel_authorization_service import FPELAuthorizationService
+from src.domain.entities.fpel import FPELStatus, compute_content_hash
+from src.infrastructure.persistence.database import DatabaseConfig, DatabaseConnection
+from src.infrastructure.persistence.migrations import run_migrations
+from src.infrastructure.persistence.repositories.fpel_repository import SqliteFPELRepository
+
+
+def _create_service(
+    tmp_path: Path,
+) -> tuple[FPELAuthorizationService, SqliteFPELRepository, DatabaseConnection]:
+    db_path = tmp_path / "test_fpel_legacy.db"
+    config = DatabaseConfig(db_path=db_path)
+    migrations_dir = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "infrastructure"
+        / "persistence"
+        / "migrations"
+    )
+    run_migrations(config, migrations_dir)
+    conn = DatabaseConnection(config=config)
+    repo = SqliteFPELRepository(connection=conn)
+    service = FPELAuthorizationService(repo=repo)
+    return service, repo, conn
+
+
+class TestLegacySnapshotRoundTrip:
+    def test_full_roundtrip_freeze_seal_check(self, tmp_path: Path) -> None:
+        service, repo, conn = _create_service(tmp_path)
+        content = '{"task": "implement feature X"}'
+        target_id = "task-legacy-001"
+
+        frozen, sealed = service.snapshot_legacy(target_id=target_id, content=content)
+
+        assert frozen.target_id == target_id
+        assert frozen.content_hash == compute_content_hash(content)
+        assert sealed.frozen_proposal_id == frozen.frozen_proposal_id
+        assert sealed.verdict == "SEALED_PASS"
+        assert sealed.source == "LEGACY_APPROVED"
+
+        decision = service.check_sealed(target_id=target_id)
+        assert decision.allowed is True
+        assert decision.status == FPELStatus.SEALED_PASS
+
+    def test_idempotent_returns_existing(self, tmp_path: Path) -> None:
+        service, repo, conn = _create_service(tmp_path)
+        content = "legacy content"
+        target_id = "task-legacy-002"
+
+        frozen1, sealed1 = service.snapshot_legacy(target_id=target_id, content=content)
+        frozen2, sealed2 = service.snapshot_legacy(target_id=target_id, content=content)
+
+        assert frozen1.frozen_proposal_id == frozen2.frozen_proposal_id
+        assert sealed1.frozen_proposal_id == sealed2.frozen_proposal_id
+        assert sealed1.source == "LEGACY_APPROVED"
+
+    def test_raises_on_failed_proposal(self, tmp_path: Path) -> None:
+        service, repo, conn = _create_service(tmp_path)
+        content = "will fail"
+        target_id = "task-legacy-003"
+
+        service.freeze(target_id=target_id, content=content)
+        service.mark_fail(target_id=target_id, reason="audit failed")
+
+        import pytest
+
+        with pytest.raises(ValueError, match="failed"):
+            service.snapshot_legacy(target_id=target_id, content=content)

--- a/tests/integration/test_fpel_legacy_snapshot_roundtrip.py
+++ b/tests/integration/test_fpel_legacy_snapshot_roundtrip.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from src.application.services.fpel_authorization_service import FPELAuthorizationService
 from src.domain.entities.fpel import FPELStatus, compute_content_hash
 from src.infrastructure.persistence.database import DatabaseConfig, DatabaseConnection
@@ -31,42 +33,156 @@ def _create_service(
 class TestLegacySnapshotRoundTrip:
     def test_full_roundtrip_freeze_seal_check(self, tmp_path: Path) -> None:
         service, repo, conn = _create_service(tmp_path)
-        content = '{"task": "implement feature X"}'
-        target_id = "task-legacy-001"
+        try:
+            content = '{"task": "implement feature X"}'
+            target_id = "task-legacy-001"
 
-        frozen, sealed = service.snapshot_legacy(target_id=target_id, content=content)
+            frozen, sealed = service.snapshot_legacy(target_id=target_id, content=content)
 
-        assert frozen.target_id == target_id
-        assert frozen.content_hash == compute_content_hash(content)
-        assert sealed.frozen_proposal_id == frozen.frozen_proposal_id
-        assert sealed.verdict == "SEALED_PASS"
-        assert sealed.source == "LEGACY_APPROVED"
+            assert frozen.target_id == target_id
+            assert frozen.content_hash == compute_content_hash(content)
+            assert sealed.frozen_proposal_id == frozen.frozen_proposal_id
+            assert sealed.verdict == "SEALED_PASS"
+            assert sealed.source == "LEGACY_APPROVED"
 
-        decision = service.check_sealed(target_id=target_id)
-        assert decision.allowed is True
-        assert decision.status == FPELStatus.SEALED_PASS
+            decision = service.check_sealed(target_id=target_id)
+            assert decision.allowed is True
+            assert decision.status == FPELStatus.SEALED_PASS
+        finally:
+            conn.close()
 
     def test_idempotent_returns_existing(self, tmp_path: Path) -> None:
         service, repo, conn = _create_service(tmp_path)
-        content = "legacy content"
-        target_id = "task-legacy-002"
+        try:
+            content = "legacy content"
+            target_id = "task-legacy-002"
 
-        frozen1, sealed1 = service.snapshot_legacy(target_id=target_id, content=content)
-        frozen2, sealed2 = service.snapshot_legacy(target_id=target_id, content=content)
+            frozen1, sealed1 = service.snapshot_legacy(target_id=target_id, content=content)
+            frozen2, sealed2 = service.snapshot_legacy(target_id=target_id, content=content)
 
-        assert frozen1.frozen_proposal_id == frozen2.frozen_proposal_id
-        assert sealed1.frozen_proposal_id == sealed2.frozen_proposal_id
-        assert sealed1.source == "LEGACY_APPROVED"
+            assert frozen1.frozen_proposal_id == frozen2.frozen_proposal_id
+            assert sealed1.frozen_proposal_id == sealed2.frozen_proposal_id
+            assert sealed1.source == "LEGACY_APPROVED"
+        finally:
+            conn.close()
 
     def test_raises_on_failed_proposal(self, tmp_path: Path) -> None:
         service, repo, conn = _create_service(tmp_path)
-        content = "will fail"
-        target_id = "task-legacy-003"
+        try:
+            content = "will fail"
+            target_id = "task-legacy-003"
 
-        service.freeze(target_id=target_id, content=content)
-        service.mark_fail(target_id=target_id, reason="audit failed")
+            service.freeze(target_id=target_id, content=content)
+            service.mark_fail(target_id=target_id, reason="audit failed")
 
-        import pytest
+            with pytest.raises(ValueError, match="failed"):
+                service.snapshot_legacy(target_id=target_id, content=content)
+        finally:
+            conn.close()
 
-        with pytest.raises(ValueError, match="failed"):
-            service.snapshot_legacy(target_id=target_id, content=content)
+    def test_raises_on_active_unsealed_proposal(self, tmp_path: Path) -> None:
+        service, repo, conn = _create_service(tmp_path)
+        try:
+            content = "unsealed content"
+            target_id = "task-legacy-004"
+
+            service.freeze(target_id=target_id, content=content)
+
+            with pytest.raises(ValueError, match="active unsealed proposal"):
+                service.snapshot_legacy(target_id=target_id, content=content)
+        finally:
+            conn.close()
+
+    def test_idempotent_after_normal_snapshot(self, tmp_path: Path) -> None:
+        service, repo, conn = _create_service(tmp_path)
+        try:
+            content = "verify no orphans"
+            target_id = "task-legacy-005"
+
+            frozen1, sealed1 = service.snapshot_legacy(target_id=target_id, content=content)
+
+            all_proposals = repo.get_all_frozen_proposals(target_id)
+            active = [p for p in all_proposals if p.is_active]
+            assert len(active) == 1
+            assert active[0].frozen_proposal_id == frozen1.frozen_proposal_id
+        finally:
+            conn.close()
+
+
+class TestAtomicSupersedeAndSave:
+    """Integration tests confirming no TOCTOU window in supersede+save."""
+
+    def test_save_frozen_with_sealed_verdict_supersede_ids_atomic(self, tmp_path: Path) -> None:
+        """After save with supersede_ids, old proposal is SUPERSEDED, new is ACTIVE."""
+        service, repo, conn = _create_service(tmp_path)
+        try:
+            from datetime import UTC, datetime
+
+            from src.domain.entities.fpel import FrozenProposal, SealedVerdict, compute_content_hash
+
+            target_id = "task-atomic-001"
+            content_old = "old content"
+            content_new = "new content"
+
+            # Seed an ACTIVE proposal
+            old_proposal = FrozenProposal(
+                frozen_proposal_id="fp-old-001",
+                target_id=target_id,
+                content_hash=compute_content_hash(content_old),
+                content=content_old,
+            )
+            repo.save_frozen_proposal(old_proposal)
+
+            # Create new proposal + sealed verdict with supersede
+            new_proposal = FrozenProposal(
+                frozen_proposal_id="fp-new-001",
+                target_id=target_id,
+                content_hash=compute_content_hash(content_new),
+                content=content_new,
+            )
+            new_verdict = SealedVerdict(
+                frozen_proposal_id="fp-new-001",
+                verdict="SEALED_PASS",
+                sealed_at=datetime.now(tz=UTC),
+                content_hash=new_proposal.content_hash,
+                source="LEGACY_APPROVED",
+            )
+            repo.save_frozen_with_sealed_verdict(
+                new_proposal, new_verdict, supersede_ids=["fp-old-001"]
+            )
+
+            # Verify: old is SUPERSEDED, new is ACTIVE — single read
+            all_proposals = repo.get_all_frozen_proposals(target_id)
+            by_id = {p.frozen_proposal_id: p for p in all_proposals}
+            assert by_id["fp-old-001"].lifecycle.value == "SUPERSEDED"
+            assert by_id["fp-new-001"].lifecycle.value == "ACTIVE"
+
+            # Only 1 active
+            active = [p for p in all_proposals if p.is_active]
+            assert len(active) == 1
+            assert active[0].frozen_proposal_id == "fp-new-001"
+        finally:
+            conn.close()
+
+    def test_freeze_uses_atomic_supersede(self, tmp_path: Path) -> None:
+        """freeze() with existing active proposal uses atomic supersede path."""
+        service, repo, conn = _create_service(tmp_path)
+        try:
+            target_id = "task-freeze-atomic"
+            content_v1 = "version 1"
+            content_v2 = "version 2"
+
+            # First freeze
+            frozen1 = service.freeze(target_id=target_id, content=content_v1)
+            assert frozen1.content_hash == compute_content_hash(content_v1)
+
+            # Second freeze — should atomically supersede first
+            frozen2 = service.freeze(target_id=target_id, content=content_v2)
+            assert frozen2.content_hash == compute_content_hash(content_v2)
+
+            all_proposals = repo.get_all_frozen_proposals(target_id)
+            active = [p for p in all_proposals if p.is_active]
+            assert len(active) == 1
+            assert active[0].frozen_proposal_id == frozen2.frozen_proposal_id
+        finally:
+            conn.close()

--- a/tests/unit/application/test_fpel_authorization_service.py
+++ b/tests/unit/application/test_fpel_authorization_service.py
@@ -115,10 +115,162 @@ class TestSealedPassAllowed:
             content_hash=frozen.content_hash,
         )
         repo.get_sealed_verdict.return_value = sealed
-
         decision = service.check_sealed(target_id=TASK_ID)
+
         assert decision.allowed is True
         assert decision.status == FPELStatus.SEALED_PASS
+
+
+class TestSnapshotLegacyTaskHashAuthority:
+    def test_task_hash_allows_check_sealed_with_same_hash(self) -> None:
+        from src.domain.entities.orchestration_task import (
+            OrchestrationTask,
+            OrchestrationTaskStatus,
+        )
+        from src.domain.services.fpel_content_hash import compute_task_hash
+
+        task = OrchestrationTask(
+            id=TASK_ID,
+            subject="Implement feature X",
+            description="Detailed description here",
+            status=OrchestrationTaskStatus.APPROVED,
+            plan_text="This is the approved plan content",
+        )
+        canonical_hash = compute_task_hash(task)
+
+        service, repo = _make_service()
+        repo.get_active_frozen_proposal.return_value = None
+        repo.get_all_frozen_proposals.return_value = []
+        repo.is_failed.return_value = False
+
+        frozen, sealed = service.snapshot_legacy_task(
+            target_id=TASK_ID,
+            plan_text=task.plan_text,
+            subject=task.subject,
+            description=task.description,
+        )
+        assert frozen.content_hash == canonical_hash
+
+        repo.get_active_frozen_proposal.return_value = frozen
+        repo.get_sealed_verdict.return_value = sealed
+        repo.get_current_content_hash.return_value = frozen.content_hash
+
+        decision = service.check_sealed(TASK_ID, current_hash=canonical_hash)
+        assert decision.allowed is True
+        assert decision.status == FPELStatus.SEALED_PASS
+
+    def test_task_hash_blocks_after_content_change(self) -> None:
+        from src.domain.entities.orchestration_task import (
+            OrchestrationTask,
+            OrchestrationTaskStatus,
+        )
+
+        task = OrchestrationTask(
+            id=TASK_ID,
+            subject="Implement feature X",
+            status=OrchestrationTaskStatus.APPROVED,
+            plan_text="Original plan",
+        )
+
+        service, repo = _make_service()
+        repo.get_active_frozen_proposal.return_value = None
+        repo.get_all_frozen_proposals.return_value = []
+        repo.is_failed.return_value = False
+
+        frozen, sealed = service.snapshot_legacy_task(
+            target_id=TASK_ID,
+            plan_text=task.plan_text,
+            subject=task.subject,
+            description=task.description,
+        )
+
+        repo.get_active_frozen_proposal.return_value = frozen
+        repo.get_sealed_verdict.return_value = sealed
+
+        changed_hash = compute_content_hash("MODIFIED plan content")
+        decision = service.check_sealed(TASK_ID, current_hash=changed_hash)
+        assert decision.allowed is False
+        assert decision.reason == SealFailureReason.HASH_MISMATCH
+
+    def test_task_hash_uses_subject_when_no_plan_text(self) -> None:
+        from src.domain.entities.orchestration_task import (
+            OrchestrationTask,
+            OrchestrationTaskStatus,
+        )
+        from src.domain.services.fpel_content_hash import compute_task_hash
+
+        task = OrchestrationTask(
+            id=TASK_ID,
+            subject="My task subject",
+            description="My task desc",
+            status=OrchestrationTaskStatus.APPROVED,
+            plan_text=None,
+        )
+        canonical_hash = compute_task_hash(task)
+
+        service, repo = _make_service()
+        repo.get_active_frozen_proposal.return_value = None
+        repo.get_all_frozen_proposals.return_value = []
+        repo.is_failed.return_value = False
+
+        frozen, _ = service.snapshot_legacy_task(
+            target_id=TASK_ID,
+            plan_text=None,
+            subject=task.subject,
+            description=task.description,
+        )
+        assert frozen.content_hash == canonical_hash
+
+
+class TestSnapshotLegacyPlanHashAuthority:
+    def test_plan_hash_allows_check_sealed_with_same_hash(self) -> None:
+        from src.domain.services.fpel_content_hash import compute_plan_hash_from_tasks
+
+        tasks = [
+            {"id": "t1", "slug": "task-one", "description": "First task"},
+            {"id": "t2", "slug": "task-two", "description": "Second task"},
+        ]
+        canonical_hash = compute_plan_hash_from_tasks(tasks)
+
+        service, repo = _make_service()
+        repo.get_active_frozen_proposal.return_value = None
+        repo.get_all_frozen_proposals.return_value = []
+        repo.is_failed.return_value = False
+
+        frozen, sealed = service.snapshot_legacy_plan(target_id="plan-123", tasks=tasks)
+        assert frozen.content_hash == canonical_hash
+
+        repo.get_active_frozen_proposal.return_value = frozen
+        repo.get_sealed_verdict.return_value = sealed
+        repo.get_current_content_hash.return_value = frozen.content_hash
+
+        decision = service.check_sealed("plan-123", current_hash=canonical_hash)
+        assert decision.allowed is True
+
+    def test_plan_hash_blocks_after_content_change(self) -> None:
+        from src.domain.services.fpel_content_hash import compute_plan_hash_from_tasks
+
+        tasks = [
+            {"id": "t1", "slug": "task-one", "description": "First task"},
+        ]
+
+        service, repo = _make_service()
+        repo.get_active_frozen_proposal.return_value = None
+        repo.get_all_frozen_proposals.return_value = []
+        repo.is_failed.return_value = False
+
+        frozen, sealed = service.snapshot_legacy_plan(target_id="plan-456", tasks=tasks)
+
+        repo.get_active_frozen_proposal.return_value = frozen
+        repo.get_sealed_verdict.return_value = sealed
+
+        changed_tasks = [
+            {"id": "t1", "slug": "task-one", "description": "MODIFIED task"},
+        ]
+        changed_hash = compute_plan_hash_from_tasks(changed_tasks)
+        decision = service.check_sealed("plan-456", current_hash=changed_hash)
+        assert decision.allowed is False
+        assert decision.reason == SealFailureReason.HASH_MISMATCH
 
 
 # ---------------------------------------------------------------------------
@@ -866,7 +1018,6 @@ class TestMarkFailOnSealedEmergencyStop:
         """mark_fail on sealed proposal persists failure — overrides seal (S13)."""
         service, repo = _make_service()
         frozen = _setup_frozen(repo)
-        # Proposal has a sealed verdict — still active
         sealed = SealedVerdict(
             frozen_proposal_id=frozen.frozen_proposal_id,
             verdict="SEALED_PASS",
@@ -879,3 +1030,120 @@ class TestMarkFailOnSealedEmergencyStop:
 
         assert result.frozen_proposal_id == frozen.frozen_proposal_id
         repo.mark_failed.assert_called_once_with(frozen.frozen_proposal_id, "emergency revocation")
+
+
+class TestSnapshotLegacyHappyPath:
+    def test_snapshot_legacy_creates_frozen_and_sealed(self) -> None:
+        content = "legacy approved content"
+        content_hash = compute_content_hash(content)
+        service, repo = _make_service()
+        repo.get_active_frozen_proposal.return_value = None
+        repo.get_sealed_verdict.return_value = None
+        repo.get_all_frozen_proposals.return_value = []
+        repo.is_failed.return_value = False
+
+        frozen, sealed = service.snapshot_legacy(target_id=TASK_ID, content=content)
+
+        assert frozen.target_id == TASK_ID
+        assert frozen.content_hash == content_hash
+        assert sealed.frozen_proposal_id == frozen.frozen_proposal_id
+        assert sealed.verdict == "SEALED_PASS"
+        assert sealed.source == "LEGACY_APPROVED"
+        assert sealed.content_hash == content_hash
+        repo.save_frozen_with_sealed_verdict.assert_called_once_with(frozen, sealed)
+
+
+class TestSnapshotLegacyIdempotent:
+    def test_snapshot_legacy_returns_existing_if_already_sealed(self) -> None:
+        content = "legacy approved content"
+        content_hash = compute_content_hash(content)
+        service, repo = _make_service()
+        frozen = _make_frozen(content=content)
+        sealed_existing = SealedVerdict(
+            frozen_proposal_id=frozen.frozen_proposal_id,
+            verdict="SEALED_PASS",
+            sealed_at=datetime.now(tz=UTC),
+            content_hash=content_hash,
+            source="LEGACY_APPROVED",
+        )
+        repo.get_active_frozen_proposal.return_value = frozen
+        repo.get_sealed_verdict.return_value = sealed_existing
+        repo.is_failed.return_value = False
+
+        frozen_result, sealed_result = service.snapshot_legacy(target_id=TASK_ID, content=content)
+
+        assert frozen_result is frozen
+        assert sealed_result is sealed_existing
+        repo.save_frozen_proposal.assert_not_called()
+        repo.save_sealed_verdict.assert_not_called()
+
+
+class TestSnapshotLegacyNoExisting:
+    def test_snapshot_legacy_creates_new_when_no_active(self) -> None:
+        content = "legacy content"
+        content_hash = compute_content_hash(content)
+        service, repo = _make_service()
+        repo.get_active_frozen_proposal.return_value = None
+        repo.get_sealed_verdict.return_value = None
+        repo.get_all_frozen_proposals.return_value = []
+        repo.is_failed.return_value = False
+
+        frozen, sealed = service.snapshot_legacy(target_id=TASK_ID, content=content)
+
+        assert frozen.content_hash == content_hash
+        assert sealed.source == "LEGACY_APPROVED"
+
+
+class TestSnapshotLegacyAlreadySealedNonLegacy:
+    def test_snapshot_legacy_returns_existing_non_legacy_sealed(self) -> None:
+        content = "some content"
+        content_hash = compute_content_hash(content)
+        service, repo = _make_service()
+        frozen = _make_frozen(content=content)
+        sealed_non_legacy = SealedVerdict(
+            frozen_proposal_id=frozen.frozen_proposal_id,
+            verdict="SEALED_PASS",
+            sealed_at=datetime.now(tz=UTC),
+            content_hash=content_hash,
+            source=None,
+        )
+        repo.get_active_frozen_proposal.return_value = frozen
+        repo.get_sealed_verdict.return_value = sealed_non_legacy
+        repo.is_failed.return_value = False
+
+        frozen_result, sealed_result = service.snapshot_legacy(target_id=TASK_ID, content=content)
+
+        assert sealed_result is sealed_non_legacy
+        repo.save_sealed_verdict.assert_not_called()
+
+
+class TestSnapshotLegacyRaisesOnFailed:
+    def test_snapshot_legacy_raises_value_error_on_failed_proposal(self) -> None:
+        service, repo = _make_service()
+        frozen = _make_frozen()
+        repo.get_active_frozen_proposal.return_value = frozen
+        repo.is_failed.return_value = True
+
+        with pytest.raises(ValueError, match="failed"):
+            service.snapshot_legacy(target_id=TASK_ID, content="content")
+
+
+class TestSnapshotLegacyThenCheckSealed:
+    def test_snapshot_legacy_then_check_sealed_returns_sealed_pass(self) -> None:
+        content = "legacy content"
+        service, repo = _make_service()
+        repo.get_active_frozen_proposal.return_value = None
+        repo.get_sealed_verdict.return_value = None
+        repo.get_all_frozen_proposals.return_value = []
+        repo.is_failed.return_value = False
+
+        frozen, sealed = service.snapshot_legacy(target_id=TASK_ID, content=content)
+
+        repo.get_active_frozen_proposal.return_value = frozen
+        repo.get_sealed_verdict.return_value = sealed
+        repo.get_current_content_hash.return_value = frozen.content_hash
+
+        decision = service.check_sealed(target_id=TASK_ID)
+
+        assert decision.allowed is True
+        assert decision.status == FPELStatus.SEALED_PASS

--- a/tests/unit/application/test_fpel_authorization_service.py
+++ b/tests/unit/application/test_fpel_authorization_service.py
@@ -368,14 +368,13 @@ class TestSealIdempotency:
 class TestReFreezeAfterFailure:
     def test_re_freeze_creates_new_id_and_supersedes_previous(self) -> None:
         """After seal failure, re-freeze creates new frozen_proposal_id and
-        marks the previous one as SUPERSEDED."""
+        marks the previous one as SUPERSEDED atomically via supersede_ids."""
         service, repo = _make_service()
         old_frozen = _make_frozen()
         # Re-freeze: no active frozen (previous was consumed), but old exists in history
         repo.get_active_frozen_proposal.return_value = None
         repo.get_all_frozen_proposals.return_value = [old_frozen]
         repo.save_frozen_proposal.return_value = None
-        repo.mark_superseded.return_value = None
 
         new_frozen = service.freeze(
             target_id=TASK_ID,
@@ -384,7 +383,13 @@ class TestReFreezeAfterFailure:
         assert new_frozen.frozen_proposal_id != old_frozen.frozen_proposal_id
         assert new_frozen.content_hash != old_frozen.content_hash
         assert new_frozen.is_active
-        repo.mark_superseded.assert_called_once_with(old_frozen.frozen_proposal_id)
+        # Atomic supersede: save_frozen_proposal called with supersede_ids
+        repo.save_frozen_proposal.assert_called_once()
+        call_kwargs = repo.save_frozen_proposal.call_args
+        assert call_kwargs.kwargs.get("supersede_ids") == [old_frozen.frozen_proposal_id] or \
+               (len(call_kwargs.args) > 1 and call_kwargs.args[1] == [old_frozen.frozen_proposal_id])
+        # mark_superseded should NOT be called (replaced by atomic supersede_ids)
+        repo.mark_superseded.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -1050,7 +1055,7 @@ class TestSnapshotLegacyHappyPath:
         assert sealed.verdict == "SEALED_PASS"
         assert sealed.source == "LEGACY_APPROVED"
         assert sealed.content_hash == content_hash
-        repo.save_frozen_with_sealed_verdict.assert_called_once_with(frozen, sealed)
+        repo.save_frozen_with_sealed_verdict.assert_called_once_with(frozen, sealed, supersede_ids=[])
 
 
 class TestSnapshotLegacyIdempotent:

--- a/tests/unit/domain/test_fpel_entities.py
+++ b/tests/unit/domain/test_fpel_entities.py
@@ -306,7 +306,7 @@ class TestAuthorizationDecision:
 
 
 class TestSealedVerdict:
-    def test_has_exactly_4_fields(self) -> None:
+    def test_has_exactly_5_fields(self) -> None:
         import dataclasses
 
         fields = {f.name for f in dataclasses.fields(SealedVerdict)}
@@ -315,6 +315,7 @@ class TestSealedVerdict:
             "verdict",
             "sealed_at",
             "content_hash",
+            "source",
         }
         assert fields == expected
 

--- a/tests/unit/domain/test_fpel_entities.py
+++ b/tests/unit/domain/test_fpel_entities.py
@@ -393,3 +393,65 @@ class TestR2HashMismatch:
         assert detect_scope_change(sealed_hash, drifted_hash) is True
         # Same failure reason applies
         assert SealFailureReason.HASH_MISMATCH.value == "HASH_MISMATCH"
+
+
+# ---------------------------------------------------------------------------
+# 12. SealedVerdict __post_init__ full validation (T1.2 / T5.1)
+# ---------------------------------------------------------------------------
+
+
+class TestSealedVerdictValidation:
+    """Parametrized validation tests for SealedVerdict.__post_init__."""
+
+    @pytest.mark.parametrize("source", [None, "LEGACY_APPROVED", "MANUAL_OVERRIDE", "AUTO_SEAL"])
+    def test_valid_sources_pass(self, source: str | None) -> None:
+        """Valid sources (including None) MUST NOT raise."""
+        SealedVerdict(
+            frozen_proposal_id="fp-valid",
+            verdict="SEALED_PASS",
+            sealed_at=datetime.now(tz=UTC),
+            content_hash="abc123",
+            source=source,
+        )
+
+    @pytest.mark.parametrize("source", ["INVALID", "LEGACY", ""])
+    def test_invalid_source_raises(self, source: str) -> None:
+        """Invalid source strings MUST raise ValueError."""
+        with pytest.raises(ValueError, match="source"):
+            SealedVerdict(
+                frozen_proposal_id="fp-bad-source",
+                verdict="SEALED_PASS",
+                sealed_at=datetime.now(tz=UTC),
+                content_hash="abc123",
+                source=source,
+            )
+
+    def test_verdict_must_be_sealed_pass(self) -> None:
+        """Only 'SEALED_PASS' is accepted as verdict."""
+        with pytest.raises(ValueError, match="verdict"):
+            SealedVerdict(
+                frozen_proposal_id="fp-bad-verdict",
+                verdict="PASS",
+                sealed_at=datetime.now(tz=UTC),
+                content_hash="abc123",
+            )
+
+    def test_empty_frozen_proposal_id_raises(self) -> None:
+        """Empty frozen_proposal_id MUST raise ValueError."""
+        with pytest.raises(ValueError, match="frozen_proposal_id"):
+            SealedVerdict(
+                frozen_proposal_id="",
+                verdict="SEALED_PASS",
+                sealed_at=datetime.now(tz=UTC),
+                content_hash="abc123",
+            )
+
+    def test_empty_content_hash_raises(self) -> None:
+        """Empty content_hash MUST raise ValueError."""
+        with pytest.raises(ValueError, match="content_hash"):
+            SealedVerdict(
+                frozen_proposal_id="fp-no-hash",
+                verdict="SEALED_PASS",
+                sealed_at=datetime.now(tz=UTC),
+                content_hash="",
+            )

--- a/tests/unit/infrastructure/persistence/repositories/test_fpel_repository.py
+++ b/tests/unit/infrastructure/persistence/repositories/test_fpel_repository.py
@@ -8,8 +8,13 @@ Tests:
 - reason persistence round-trip (R6)
 """
 
+from datetime import UTC, datetime
 from pathlib import Path
+from sqlite3 import IntegrityError
 
+import pytest
+
+from src.domain.entities.fpel import FrozenProposal, SealedVerdict, compute_content_hash
 from src.infrastructure.persistence.database import DatabaseConfig, DatabaseConnection
 from src.infrastructure.persistence.migrations import run_migrations
 from src.infrastructure.persistence.repositories.fpel_repository import SqliteFPELRepository
@@ -243,3 +248,102 @@ class TestReasonRoundTrip:
             ).fetchone()
         assert row is not None
         assert row["reason"] == "blocked by audit"
+
+
+class TestSealedVerdictSourceRoundTrip:
+    def test_source_none_round_trip(self, tmp_path: Path) -> None:
+        conn, repo = _create_repo(tmp_path)
+        from datetime import UTC, datetime
+
+        from src.domain.entities.fpel import SealedVerdict
+
+        with conn as c:
+            c.execute(
+                "INSERT INTO frozen_proposals (frozen_proposal_id, target_id, content_hash, content) "
+                "VALUES (?, ?, ?, ?)",
+                ("fp-src-001", "target-src", "hash-src", "content-src"),
+            )
+            c.commit()
+
+        sv = SealedVerdict(
+            frozen_proposal_id="fp-src-001",
+            verdict="SEALED_PASS",
+            sealed_at=datetime.now(tz=UTC),
+            content_hash="hash-src",
+            source=None,
+        )
+        repo.save_sealed_verdict(sv)
+
+        result = repo.get_sealed_verdict("fp-src-001")
+        assert result is not None
+        assert result.source is None
+
+    def test_source_legacy_approved_round_trip(self, tmp_path: Path) -> None:
+        conn, repo = _create_repo(tmp_path)
+        from datetime import UTC, datetime
+
+        from src.domain.entities.fpel import SealedVerdict
+
+        with conn as c:
+            c.execute(
+                "INSERT INTO frozen_proposals (frozen_proposal_id, target_id, content_hash, content) "
+                "VALUES (?, ?, ?, ?)",
+                ("fp-src-002", "target-src2", "hash-src2", "content-src2"),
+            )
+            c.commit()
+
+        sv = SealedVerdict(
+            frozen_proposal_id="fp-src-002",
+            verdict="SEALED_PASS",
+            sealed_at=datetime.now(tz=UTC),
+            content_hash="hash-src2",
+            source="LEGACY_APPROVED",
+        )
+        repo.save_sealed_verdict(sv)
+
+        result = repo.get_sealed_verdict("fp-src-002")
+        assert result is not None
+        assert result.source == "LEGACY_APPROVED"
+
+
+class TestSaveFrozenWithSealedVerdictAtomic:
+    def test_atomic_save_persists_both(self, tmp_path: Path) -> None:
+        conn, repo = _create_repo(tmp_path)
+        proposal = FrozenProposal(
+            frozen_proposal_id="fp-atomic-001",
+            target_id="target-atomic",
+            content_hash=compute_content_hash("atomic content"),
+            content="atomic content",
+        )
+        verdict = SealedVerdict(
+            frozen_proposal_id="fp-atomic-001",
+            verdict="SEALED_PASS",
+            sealed_at=datetime.now(tz=UTC),
+            content_hash=proposal.content_hash,
+            source="LEGACY_APPROVED",
+        )
+        repo.save_frozen_with_sealed_verdict(proposal, verdict)
+
+        assert repo.get_active_frozen_proposal("target-atomic") is not None
+        assert repo.get_sealed_verdict("fp-atomic-001") is not None
+
+    def test_atomic_failure_leaves_no_partial_state(self, tmp_path: Path) -> None:
+        conn, repo = _create_repo(tmp_path)
+        proposal = FrozenProposal(
+            frozen_proposal_id="fp-atomic-fail",
+            target_id="target-fail",
+            content_hash=compute_content_hash("will fail"),
+            content="will fail",
+        )
+        bad_verdict = SealedVerdict(
+            frozen_proposal_id="NONEXISTENT_FK",
+            verdict="SEALED_PASS",
+            sealed_at=datetime.now(tz=UTC),
+            content_hash="hash",
+            source="LEGACY_APPROVED",
+        )
+        with pytest.raises(IntegrityError):
+            repo.save_frozen_with_sealed_verdict(proposal, bad_verdict)
+
+        assert repo.get_active_frozen_proposal("target-fail") is None
+        assert repo.get_sealed_verdict("fp-atomic-fail") is None

--- a/tests/unit/interfaces/cli/test_fpel_cli.py
+++ b/tests/unit/interfaces/cli/test_fpel_cli.py
@@ -465,3 +465,60 @@ class TestFailCommand:
             result = runner.invoke(app, ["fail", "--target-id", TARGET_ID])
 
         assert result.exit_code == 12
+
+
+class TestSnapshotLegacyCommand:
+    def test_snapshot_legacy_success_exit_0(self) -> None:
+        service, repo = _make_service()
+        repo.get_active_frozen_proposal.return_value = None
+        repo.get_sealed_verdict.return_value = None
+        repo.get_all_frozen_proposals.return_value = []
+        repo.is_failed.return_value = False
+
+        with _patch_service(service):
+            result = runner.invoke(
+                app,
+                ["snapshot-legacy", "--target-id", TARGET_ID, "--content", CONTENT],
+            )
+
+        assert result.exit_code == 0
+        assert "LEGACY_APPROVED" in result.output
+
+    def test_snapshot_legacy_failed_proposal_exit_12(self) -> None:
+        service, repo = _make_service()
+        frozen = _make_frozen()
+        repo.get_active_frozen_proposal.return_value = frozen
+        repo.is_failed.return_value = True
+
+        with _patch_service(service):
+            result = runner.invoke(
+                app,
+                ["snapshot-legacy", "--target-id", TARGET_ID, "--content", CONTENT],
+            )
+
+        assert result.exit_code == 12
+
+    def test_snapshot_legacy_missing_content_exit_12(self) -> None:
+        service, _ = _make_service()
+
+        with _patch_service(service):
+            result = runner.invoke(
+                app,
+                ["snapshot-legacy", "--target-id", TARGET_ID],
+            )
+
+        assert result.exit_code != 0
+
+    def test_snapshot_legacy_service_error_exit_12(self) -> None:
+        service, repo = _make_service()
+        frozen = _make_frozen()
+        repo.get_active_frozen_proposal.return_value = frozen
+        repo.is_failed.return_value = True
+
+        with _patch_service(service):
+            result = runner.invoke(
+                app,
+                ["snapshot-legacy", "--target-id", TARGET_ID, "--content", CONTENT],
+            )
+
+        assert result.exit_code == 12

--- a/tests/unit/interfaces/cli/test_fpel_cli.py
+++ b/tests/unit/interfaces/cli/test_fpel_cli.py
@@ -498,7 +498,7 @@ class TestSnapshotLegacyCommand:
 
         assert result.exit_code == 12
 
-    def test_snapshot_legacy_missing_content_exit_12(self) -> None:
+    def test_snapshot_legacy_missing_source_exit_1(self) -> None:
         service, _ = _make_service()
 
         with _patch_service(service):
@@ -507,13 +507,16 @@ class TestSnapshotLegacyCommand:
                 ["snapshot-legacy", "--target-id", TARGET_ID],
             )
 
-        assert result.exit_code != 0
+        assert result.exit_code == 1
+        assert "exactly one" in result.output
 
-    def test_snapshot_legacy_service_error_exit_12(self) -> None:
+    def test_snapshot_legacy_active_unsealed_exits_13(self) -> None:
+        """snapshot-legacy with active unsealed proposal exits 13 (T4.1 / T5.2)."""
         service, repo = _make_service()
         frozen = _make_frozen()
         repo.get_active_frozen_proposal.return_value = frozen
-        repo.is_failed.return_value = True
+        repo.is_failed.return_value = False
+        repo.get_sealed_verdict.return_value = None  # no seal → active unsealed
 
         with _patch_service(service):
             result = runner.invoke(
@@ -521,4 +524,5 @@ class TestSnapshotLegacyCommand:
                 ["snapshot-legacy", "--target-id", TARGET_ID, "--content", CONTENT],
             )
 
-        assert result.exit_code == 12
+        assert result.exit_code == 13
+        assert "active unsealed" in result.output


### PR DESCRIPTION
## Summary

Adds legacy APPROVED snapshot mechanism to FPEL, closing #47.

Tasks approved before FPEL was enabled have no frozen proposal — permanently blocked when FPEL is active. `snapshot_legacy()` retroactively brings them into the FPEL audit trail by creating a frozen proposal + sealed verdict with `source='LEGACY_APPROVED'`.

## Changes

### Schema
- **Migration 036**: `source TEXT` column on `sealed_verdicts` (nullable, default NULL)

### Domain
- **SealedVerdict**: `source: str | None = None` with full `__post_init__` validation — `frozen_proposal_id` non-empty, `verdict == "SEALED_PASS"`, `content_hash` non-empty, `source` in `{LEGACY_APPROVED, MANUAL_OVERRIDE, AUTO_SEAL}` or `None`
- **FPELRepository**: `supersede_ids: Sequence[str] = ()` on `save_frozen_proposal` and `save_frozen_with_sealed_verdict` for single-transaction atomicity

### Application
- **`snapshot_legacy_task(target_id, plan_text, subject, description)`**: Hash-authority compliant — canonical task hash. **Preferred path.**
- **`snapshot_legacy_plan(target_id, tasks)`**: Hash-authority compliant — canonical plan hash. **Preferred path.**
- **`snapshot_legacy(target_id, content)`**: Low-level escape hatch — NOT hash-authority compliant.
- **Atomic save**: `save_frozen_with_sealed_verdict` and `save_frozen_proposal` now accept `supersede_ids` — supersede UPDATE + INSERT run in a single SQLite transaction, eliminating TOCTOU race.
- **Active unsealed guard**: Raises `ValueError` if active unsealed proposal exists.
- Bypasses checker requirements (legacy tasks pre-date FPEL)
- Idempotent: returns existing if already sealed
- FAIL guard: raises `ValueError` for failed proposals
- `check_sealed()`: No code change — auto-resolves via sealed_verdicts table

### CLI
- **`fpel snapshot-legacy --target-id X --from-task TASK_ID`**: Hash-authority compliant
- **`fpel snapshot-legacy --target-id X --from-plan PLAN_ID`**: Hash-authority compliant
- **`fpel snapshot-legacy --target-id X --content TEXT`**: Low-level, shows yellow warning
- Exit 13 for active-unsealed ValueError, exit 12 for other ValueErrors
- Exactly one of `--content`, `--from-task`, `--from-plan` required

### Tests
- Entity: SealedVerdict full validation (10 parametrized tests)
- Repo: atomic save with supersede_ids (2 tests), source round-trip (2 tests)
- Service: hash authority task/plan allow+block, active unsealed guard (14 tests)
- CLI: exit codes 12/13, source validation (4 tests)
- Integration: atomic supersede+save, no orphans, active unsealed guard (5 tests)
- **Total: 2760 passed**, ruff + mypy clean

## Design Decisions

| Decision | Choice |
|----------|--------|
| Source storage | Nullable TEXT + `__post_init__` whitelist validation |
| Checker bypass | No synthetic reports — direct seal |
| Idempotency | Return existing if frozen+sealed |
| FAIL guard | Raise `ValueError` — terminal invariant |
| Hash authority | `--from-task` / `--from-plan` preferred — canonical hash matches runtime |
| Content param | Low-level escape hatch, NOT hash-authority compliant — CLI shows warning |
| Atomicity | Supersede UPDATE + frozen INSERT + sealed INSERT in single `with conn` block. No TOCTOU gap. |
| Active unsealed guard | Raises `ValueError` — prevents silent supersede of in-progress FPEL flow |
| Exit codes | 12 = failed proposal / other errors, 13 = active unsealed |
| mark_superseded | Deprecated — kept for backward compat, service layer uses atomic path |

## Review Comments Resolved

All Copilot, CodeRabbit, and Codex comments from commits `4cbc944` and `8509ead` addressed:
- ✅ Atomic freeze+seal (CodeRabbit + Copilot + Codex)
- ✅ Seal hash bound to frozen snapshot (CodeRabbit + Copilot + Codex)
- ✅ SealedVerdict.source constrained (CodeRabbit)
- ✅ DB connections closed in tests (CodeRabbit)
- ✅ CLI test assertions fixed (Copilot)
- ✅ Duplicate CLI test removed (Copilot)
- ✅ Active proposal rejection guard (Codex)
- ✅ TOCTOU race fixed via single-transaction atomicity (Judgment Day)

## Test Plan

- [x] `uv run ruff check src/ tests/` — All checks passed
- [x] `uv run ruff format --check src/ tests/` — All files formatted
- [x] `uv run mypy src/` — Clean
- [x] `uv run pytest tests/ -q` — **2760 passed**, 107 skipped, 0 failed

Closes #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Introduced `snapshot-legacy` CLI command to create sealed verdicts from legacy content, tasks, or plans with atomic operations
* Sealed verdicts now record and display their origin source for comprehensive audit trailing and compliance verification
* Enhanced system reliability through improved atomic proposal superseding during persistence operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->