### PR TITLE
feat(fpel): add target-id mismatch guard (#51)

### DIFF
--- a/src/interfaces/cli/commands/fpel.py
+++ b/src/interfaces/cli/commands/fpel.py
@@ -99,8 +99,15 @@ def freeze_proposal(
         bool,
         typer.Option(
             "--allow-target-mismatch",
-            "--allow-target-alias",
             help="Allow target_id to differ from source ID",
+        ),
+    ] = False,
+    allow_target_alias: Annotated[
+        bool,
+        typer.Option(
+            "--allow-target-alias",
+            hidden=True,
+            help="Backward-compatible alias for --allow-target-mismatch",
         ),
     ] = False,
 ) -> None:
@@ -110,6 +117,7 @@ def freeze_proposal(
     (canonical hash matches what check_sealed() computes at runtime).
     Use --content for low-level/arbitrary content (not hash-authority compliant).
     """
+    _allow_override = allow_target_mismatch or allow_target_alias
     sources = [content is not None, from_task is not None, from_plan is not None]
     if sum(sources) != 1:
         console.print(
@@ -129,7 +137,7 @@ def freeze_proposal(
             console.print(f"[red]Error: Task '{from_task}' not found[/red]")
             raise typer.Exit(1)
         should_proceed, msg = _validate_target_id_match(
-            target_id, from_task, "task", allow_target_mismatch
+            target_id, from_task, "task", _allow_override
         )
         if not should_proceed:
             console.print(f"[red]{msg}[/red]")
@@ -167,7 +175,7 @@ def freeze_proposal(
             )
             raise typer.Exit(1)
         should_proceed, msg = _validate_target_id_match(
-            target_id, from_plan, "plan", allow_target_mismatch
+            target_id, from_plan, "plan", _allow_override
         )
         if not should_proceed:
             console.print(f"[red]{msg}[/red]")
@@ -295,8 +303,15 @@ def snapshot_legacy(
         bool,
         typer.Option(
             "--allow-target-mismatch",
-            "--allow-target-alias",
             help="Allow target_id to differ from source ID",
+        ),
+    ] = False,
+    allow_target_alias: Annotated[
+        bool,
+        typer.Option(
+            "--allow-target-alias",
+            hidden=True,
+            help="Backward-compatible alias for --allow-target-mismatch",
         ),
     ] = False,
 ) -> None:
@@ -306,6 +321,7 @@ def snapshot_legacy(
     (canonical hash matches what check_sealed() computes at runtime).
     Use --content for low-level/arbitrary content (NOT hash-authority compliant).
     """
+    _allow_override = allow_target_mismatch or allow_target_alias
     sources = [content is not None, from_task is not None, from_plan is not None]
     if sum(sources) != 1:
         console.print(
@@ -334,7 +350,7 @@ def snapshot_legacy(
                 console.print(f"[red]Error: Task '{from_task}' not found[/red]")
                 raise typer.Exit(1)
             should_proceed, msg = _validate_target_id_match(
-                target_id, from_task, "task", allow_target_mismatch
+                target_id, from_task, "task", _allow_override
             )
             if not should_proceed:
                 console.print(f"[red]{msg}[/red]")
@@ -374,7 +390,7 @@ def snapshot_legacy(
                 )
                 raise typer.Exit(1)
             should_proceed, msg = _validate_target_id_match(
-                target_id, from_plan, "plan", allow_target_mismatch
+                target_id, from_plan, "plan", _allow_override
             )
             if not should_proceed:
                 console.print(f"[red]{msg}[/red]")

--- a/src/interfaces/cli/commands/fpel.py
+++ b/src/interfaces/cli/commands/fpel.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Annotated
+import logging
+from typing import Annotated, Literal
 
 import typer
 from rich.console import Console
@@ -11,6 +12,7 @@ from src.domain.entities.fpel import SealFailureReason
 
 app = typer.Typer(help="FPEL: freeze, check, seal, and verify proposals.")
 console = Console()
+logger = logging.getLogger(__name__)
 
 # Map SealFailureReason → unique CLI exit code
 _SEAL_FAILURE_EXIT_CODES: dict[SealFailureReason, int] = {
@@ -46,6 +48,34 @@ def _require_fpel_service():
     return service
 
 
+def _validate_target_id_match(
+    target_id: str,
+    source_id: str,
+    source_type: Literal["task", "plan"],
+    allow_mismatch: bool,
+) -> tuple[bool, str]:
+    """Validate target_id matches source entity ID.
+
+    Returns (should_proceed, message):
+      - (True, ""): IDs match, proceed silently.
+      - (True, "Warning: ..."): IDs differ but allowed, proceed with warning.
+      - (False, "Error: ..."): IDs differ and not allowed, abort.
+    """
+    if not target_id or target_id == source_id:
+        return True, ""
+    if allow_mismatch:
+        return (
+            True,
+            f"Warning: --target-id ({target_id}) differs from "
+            f"--from-{source_type} ({source_id}). Proceeding with --allow-target-mismatch.",
+        )
+    return (
+        False,
+        f"Error: --target-id ({target_id}) does not match "
+        f"--from-{source_type} ({source_id}). Use --allow-target-mismatch to override.",
+    )
+
+
 @app.command("freeze")
 def freeze_proposal(
     target_id: Annotated[str, typer.Option("--target-id", help="Target task or workflow ID")],
@@ -65,6 +95,13 @@ def freeze_proposal(
             "--from-plan", help="Plan session ID — freeze with canonical hash from plan state"
         ),
     ] = None,
+    allow_target_mismatch: Annotated[
+        bool,
+        typer.Option(
+            "--allow-target-mismatch", "--allow-target-alias",
+            help="Allow target_id to differ from source ID",
+        ),
+    ] = False,
 ) -> None:
     """Create an immutable frozen snapshot of a proposal.
 
@@ -90,6 +127,13 @@ def freeze_proposal(
         if task is None:
             console.print(f"[red]Error: Task '{from_task}' not found[/red]")
             raise typer.Exit(1)
+        should_proceed, msg = _validate_target_id_match(target_id, from_task, "task", allow_target_mismatch)
+        if not should_proceed:
+            console.print(f"[red]{msg}[/red]")
+            raise typer.Exit(1)
+        if msg:
+            console.print(f"[yellow]{msg}[/yellow]")
+            logger.warning("Target-ID mismatch override: target=%s source=%s type=%s", target_id, from_task, "task")
         frozen = service.freeze_task(
             target_id=target_id,
             plan_text=task.plan_text,
@@ -114,11 +158,19 @@ def freeze_proposal(
                 f"[red]Error: Plan session_id '{plan.session_id}' does not match --from-plan '{from_plan}'[/red]"
             )
             raise typer.Exit(1)
+        should_proceed, msg = _validate_target_id_match(target_id, from_plan, "plan", allow_target_mismatch)
+        if not should_proceed:
+            console.print(f"[red]{msg}[/red]")
+            raise typer.Exit(1)
+        if msg:
+            console.print(f"[yellow]{msg}[/yellow]")
+            logger.warning("Target-ID mismatch override: target=%s source=%s type=%s", target_id, from_plan, "plan")
         tasks_data = [
             {"id": t.id, "slug": t.slug, "description": t.description} for t in plan.tasks
         ]
         frozen = service.freeze_plan(target_id=target_id, tasks=tasks_data)
     else:
+        # No guard: content route has no entity ID for comparison.
         frozen = service.freeze(target_id=target_id, content=content)
 
     console.print("[green]Proposal frozen.[/green]")
@@ -224,6 +276,13 @@ def snapshot_legacy(
             "--from-plan", help="Plan session ID — snapshot with canonical plan hash authority"
         ),
     ] = None,
+    allow_target_mismatch: Annotated[
+        bool,
+        typer.Option(
+            "--allow-target-mismatch", "--allow-target-alias",
+            help="Allow target_id to differ from source ID",
+        ),
+    ] = False,
 ) -> None:
     """Create a legacy-approved snapshot (freeze + seal with source=LEGACY_APPROVED).
 
@@ -242,6 +301,7 @@ def snapshot_legacy(
 
     try:
         if content is not None:
+            # No guard: content route has no entity ID for comparison.
             console.print(
                 "[yellow]Warning: --content is NOT hash-authority compliant. "
                 "Post-snapshot runtime checks may produce HASH_MISMATCH. "
@@ -257,6 +317,13 @@ def snapshot_legacy(
             if task is None:
                 console.print(f"[red]Error: Task '{from_task}' not found[/red]")
                 raise typer.Exit(1)
+            should_proceed, msg = _validate_target_id_match(target_id, from_task, "task", allow_target_mismatch)
+            if not should_proceed:
+                console.print(f"[red]{msg}[/red]")
+                raise typer.Exit(1)
+            if msg:
+                console.print(f"[yellow]{msg}[/yellow]")
+                logger.warning("Target-ID mismatch override: target=%s source=%s type=%s", target_id, from_task, "task")
             frozen, sealed = service.snapshot_legacy_task(
                 target_id=target_id,
                 plan_text=task.plan_text,
@@ -283,6 +350,13 @@ def snapshot_legacy(
                     f"[red]Error: Plan session_id '{plan.session_id}' does not match --from-plan '{from_plan}'[/red]"
                 )
                 raise typer.Exit(1)
+            should_proceed, msg = _validate_target_id_match(target_id, from_plan, "plan", allow_target_mismatch)
+            if not should_proceed:
+                console.print(f"[red]{msg}[/red]")
+                raise typer.Exit(1)
+            if msg:
+                console.print(f"[yellow]{msg}[/yellow]")
+                logger.warning("Target-ID mismatch override: target=%s source=%s type=%s", target_id, from_plan, "plan")
             tasks_data = [
                 {"id": t.id, "slug": t.slug, "description": t.description} for t in plan.tasks
             ]

--- a/src/interfaces/cli/commands/fpel.py
+++ b/src/interfaces/cli/commands/fpel.py
@@ -98,7 +98,8 @@ def freeze_proposal(
     allow_target_mismatch: Annotated[
         bool,
         typer.Option(
-            "--allow-target-mismatch", "--allow-target-alias",
+            "--allow-target-mismatch",
+            "--allow-target-alias",
             help="Allow target_id to differ from source ID",
         ),
     ] = False,
@@ -127,13 +128,20 @@ def freeze_proposal(
         if task is None:
             console.print(f"[red]Error: Task '{from_task}' not found[/red]")
             raise typer.Exit(1)
-        should_proceed, msg = _validate_target_id_match(target_id, from_task, "task", allow_target_mismatch)
+        should_proceed, msg = _validate_target_id_match(
+            target_id, from_task, "task", allow_target_mismatch
+        )
         if not should_proceed:
             console.print(f"[red]{msg}[/red]")
             raise typer.Exit(1)
         if msg:
             console.print(f"[yellow]{msg}[/yellow]")
-            logger.warning("Target-ID mismatch override: target=%s source=%s type=%s", target_id, from_task, "task")
+            logger.warning(
+                "Target-ID mismatch override: target=%s source=%s type=%s",
+                target_id,
+                from_task,
+                "task",
+            )
         frozen = service.freeze_task(
             target_id=target_id,
             plan_text=task.plan_text,
@@ -158,13 +166,20 @@ def freeze_proposal(
                 f"[red]Error: Plan session_id '{plan.session_id}' does not match --from-plan '{from_plan}'[/red]"
             )
             raise typer.Exit(1)
-        should_proceed, msg = _validate_target_id_match(target_id, from_plan, "plan", allow_target_mismatch)
+        should_proceed, msg = _validate_target_id_match(
+            target_id, from_plan, "plan", allow_target_mismatch
+        )
         if not should_proceed:
             console.print(f"[red]{msg}[/red]")
             raise typer.Exit(1)
         if msg:
             console.print(f"[yellow]{msg}[/yellow]")
-            logger.warning("Target-ID mismatch override: target=%s source=%s type=%s", target_id, from_plan, "plan")
+            logger.warning(
+                "Target-ID mismatch override: target=%s source=%s type=%s",
+                target_id,
+                from_plan,
+                "plan",
+            )
         tasks_data = [
             {"id": t.id, "slug": t.slug, "description": t.description} for t in plan.tasks
         ]
@@ -279,7 +294,8 @@ def snapshot_legacy(
     allow_target_mismatch: Annotated[
         bool,
         typer.Option(
-            "--allow-target-mismatch", "--allow-target-alias",
+            "--allow-target-mismatch",
+            "--allow-target-alias",
             help="Allow target_id to differ from source ID",
         ),
     ] = False,
@@ -317,13 +333,20 @@ def snapshot_legacy(
             if task is None:
                 console.print(f"[red]Error: Task '{from_task}' not found[/red]")
                 raise typer.Exit(1)
-            should_proceed, msg = _validate_target_id_match(target_id, from_task, "task", allow_target_mismatch)
+            should_proceed, msg = _validate_target_id_match(
+                target_id, from_task, "task", allow_target_mismatch
+            )
             if not should_proceed:
                 console.print(f"[red]{msg}[/red]")
                 raise typer.Exit(1)
             if msg:
                 console.print(f"[yellow]{msg}[/yellow]")
-                logger.warning("Target-ID mismatch override: target=%s source=%s type=%s", target_id, from_task, "task")
+                logger.warning(
+                    "Target-ID mismatch override: target=%s source=%s type=%s",
+                    target_id,
+                    from_task,
+                    "task",
+                )
             frozen, sealed = service.snapshot_legacy_task(
                 target_id=target_id,
                 plan_text=task.plan_text,
@@ -350,13 +373,20 @@ def snapshot_legacy(
                     f"[red]Error: Plan session_id '{plan.session_id}' does not match --from-plan '{from_plan}'[/red]"
                 )
                 raise typer.Exit(1)
-            should_proceed, msg = _validate_target_id_match(target_id, from_plan, "plan", allow_target_mismatch)
+            should_proceed, msg = _validate_target_id_match(
+                target_id, from_plan, "plan", allow_target_mismatch
+            )
             if not should_proceed:
                 console.print(f"[red]{msg}[/red]")
                 raise typer.Exit(1)
             if msg:
                 console.print(f"[yellow]{msg}[/yellow]")
-                logger.warning("Target-ID mismatch override: target=%s source=%s type=%s", target_id, from_plan, "plan")
+                logger.warning(
+                    "Target-ID mismatch override: target=%s source=%s type=%s",
+                    target_id,
+                    from_plan,
+                    "plan",
+                )
             tasks_data = [
                 {"id": t.id, "slug": t.slug, "description": t.description} for t in plan.tasks
             ]

--- a/tests/unit/application/test_fpel_authorization_service.py
+++ b/tests/unit/application/test_fpel_authorization_service.py
@@ -386,8 +386,9 @@ class TestReFreezeAfterFailure:
         # Atomic supersede: save_frozen_proposal called with supersede_ids
         repo.save_frozen_proposal.assert_called_once()
         call_kwargs = repo.save_frozen_proposal.call_args
-        assert call_kwargs.kwargs.get("supersede_ids") == [old_frozen.frozen_proposal_id] or \
-               (len(call_kwargs.args) > 1 and call_kwargs.args[1] == [old_frozen.frozen_proposal_id])
+        assert call_kwargs.kwargs.get("supersede_ids") == [old_frozen.frozen_proposal_id] or (
+            len(call_kwargs.args) > 1 and call_kwargs.args[1] == [old_frozen.frozen_proposal_id]
+        )
         # mark_superseded should NOT be called (replaced by atomic supersede_ids)
         repo.mark_superseded.assert_not_called()
 
@@ -1055,7 +1056,9 @@ class TestSnapshotLegacyHappyPath:
         assert sealed.verdict == "SEALED_PASS"
         assert sealed.source == "LEGACY_APPROVED"
         assert sealed.content_hash == content_hash
-        repo.save_frozen_with_sealed_verdict.assert_called_once_with(frozen, sealed, supersede_ids=[])
+        repo.save_frozen_with_sealed_verdict.assert_called_once_with(
+            frozen, sealed, supersede_ids=[]
+        )
 
 
 class TestSnapshotLegacyIdempotent:

--- a/tests/unit/interfaces/cli/test_fpel_cli.py
+++ b/tests/unit/interfaces/cli/test_fpel_cli.py
@@ -621,8 +621,10 @@ class TestTargetIdValidation:
     def test_freeze_from_task_mismatch_exits_1(self) -> None:
         service, repo = _make_service()
         repo.get_all_frozen_proposals.return_value = []
-        with (_patch_service(service), _mock_from_task("task-abc")):
-            result = runner.invoke(app, ["freeze", "--target-id", "task-xyz", "--from-task", "task-abc"])
+        with _patch_service(service), _mock_from_task("task-abc"):
+            result = runner.invoke(
+                app, ["freeze", "--target-id", "task-xyz", "--from-task", "task-abc"]
+            )
         assert result.exit_code == 1
         assert "task-xyz" in result.output
         assert "task-abc" in result.output
@@ -630,8 +632,10 @@ class TestTargetIdValidation:
     def test_freeze_from_plan_mismatch_exits_1(self) -> None:
         service, repo = _make_service()
         repo.get_all_frozen_proposals.return_value = []
-        with (_patch_service(service), _mock_from_plan("plan-111")):
-            result = runner.invoke(app, ["freeze", "--target-id", "plan-222", "--from-plan", "plan-111"])
+        with _patch_service(service), _mock_from_plan("plan-111"):
+            result = runner.invoke(
+                app, ["freeze", "--target-id", "plan-222", "--from-plan", "plan-111"]
+            )
         assert result.exit_code == 1
 
     def test_snapshot_from_task_mismatch_exits_1(self) -> None:
@@ -639,8 +643,10 @@ class TestTargetIdValidation:
         repo.get_active_frozen_proposal.return_value = None
         repo.get_sealed_verdict.return_value = None
         repo.is_failed.return_value = False
-        with (_patch_service(service), _mock_from_task("task-abc")):
-            result = runner.invoke(app, ["snapshot-legacy", "--target-id", "task-xyz", "--from-task", "task-abc"])
+        with _patch_service(service), _mock_from_task("task-abc"):
+            result = runner.invoke(
+                app, ["snapshot-legacy", "--target-id", "task-xyz", "--from-task", "task-abc"]
+            )
         assert result.exit_code == 1
 
     def test_snapshot_from_plan_mismatch_exits_1(self) -> None:
@@ -648,8 +654,10 @@ class TestTargetIdValidation:
         repo.get_active_frozen_proposal.return_value = None
         repo.get_sealed_verdict.return_value = None
         repo.is_failed.return_value = False
-        with (_patch_service(service), _mock_from_plan("plan-111")):
-            result = runner.invoke(app, ["snapshot-legacy", "--target-id", "plan-222", "--from-plan", "plan-111"])
+        with _patch_service(service), _mock_from_plan("plan-111"):
+            result = runner.invoke(
+                app, ["snapshot-legacy", "--target-id", "plan-222", "--from-plan", "plan-111"]
+            )
         assert result.exit_code == 1
 
     # --- Content-route tests (fixed assertions) ---
@@ -658,7 +666,9 @@ class TestTargetIdValidation:
         service, repo = _make_service()
         repo.get_all_frozen_proposals.return_value = []
         with _patch_service(service):
-            result = runner.invoke(app, ["freeze", "--target-id", "anything-at-all", "--content", "data"])
+            result = runner.invoke(
+                app, ["freeze", "--target-id", "anything-at-all", "--content", "data"]
+            )
         assert result.exit_code == 0
         assert "does not match" not in result.output
 
@@ -668,6 +678,8 @@ class TestTargetIdValidation:
         repo.get_sealed_verdict.return_value = None
         repo.is_failed.return_value = False
         with _patch_service(service):
-            result = runner.invoke(app, ["snapshot-legacy", "--target-id", "anything-at-all", "--content", "data"])
+            result = runner.invoke(
+                app, ["snapshot-legacy", "--target-id", "anything-at-all", "--content", "data"]
+            )
         assert result.exit_code == 0
         assert "does not match" not in result.output

--- a/tests/unit/interfaces/cli/test_fpel_cli.py
+++ b/tests/unit/interfaces/cli/test_fpel_cli.py
@@ -29,7 +29,7 @@ from src.domain.entities.fpel import (
     compute_content_hash,
 )
 from src.domain.ports.fpel_repository import FPELRepository
-from src.interfaces.cli.commands.fpel import app
+from src.interfaces.cli.commands.fpel import _validate_target_id_match, app
 
 runner = CliRunner()
 
@@ -526,3 +526,148 @@ class TestSnapshotLegacyCommand:
 
         assert result.exit_code == 13
         assert "active unsealed" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Target-ID Mismatch Guard (Issue #51)
+# ---------------------------------------------------------------------------
+
+
+def _mock_from_task(task_id: str):
+    """Patch get_container() chain so --from-task route resolves a mock task.
+
+    FRAGILE: patches src.infrastructure.persistence.container.get_container.
+    If that import path changes, this helper and all tests using it will break.
+    """
+    task = MagicMock()
+    task.id = task_id
+    task.plan_text = "test plan"
+    task.subject = "test subject"
+    task.description = "test description"
+    mock_board = MagicMock()
+    mock_board.get.return_value = task
+    mock_container = MagicMock()
+    mock_container.task_board_service.return_value = mock_board
+    return patch(
+        "src.infrastructure.persistence.container.get_container",
+        return_value=mock_container,
+    )
+
+
+def _mock_from_plan(session_id: str):
+    """Patch get_plan_state_path() + PlanState.load() for --from-plan route.
+
+    FRAGILE: patches src.interfaces.cli.commands.workflow.get_plan_state_path
+    and src.application.services.workflow.state.PlanState.load.
+    If either import path changes, this helper and all tests using it will break.
+
+    Returns a single ExitStack-based context manager that applies both patches.
+    """
+    from contextlib import ExitStack
+
+    plan = MagicMock()
+    plan.session_id = session_id
+    plan.tasks = []
+    plan_path = MagicMock()
+    plan_path.exists.return_value = True
+
+    class _PlanMock(ExitStack):
+        def __enter__(self):
+            super().__enter__()
+            p1 = self.enter_context(
+                patch(
+                    "src.interfaces.cli.commands.workflow.get_plan_state_path",
+                    return_value=plan_path,
+                )
+            )
+            p2 = self.enter_context(
+                patch(
+                    "src.application.services.workflow.state.PlanState.load",
+                    return_value=plan,
+                )
+            )
+            return (p1, p2)
+
+    return _PlanMock()
+
+
+class TestTargetIdValidation:
+    """10 tests: 4 unit (pure helper), 4 wiring (CLI integration), 2 content-route."""
+
+    # --- Unit tests on pure helper (no mocks needed) ---
+
+    def test_match_returns_proceed_empty(self) -> None:
+        result = _validate_target_id_match("task-abc", "task-abc", "task", False)
+        assert result == (True, "")
+
+    def test_mismatch_deny_returns_error(self) -> None:
+        should_proceed, msg = _validate_target_id_match("task-xyz", "task-abc", "task", False)
+        assert should_proceed is False
+        assert "Error" in msg
+        assert "task-xyz" in msg
+        assert "task-abc" in msg
+
+    def test_mismatch_allow_returns_warning(self) -> None:
+        should_proceed, msg = _validate_target_id_match("task-xyz", "task-abc", "plan", True)
+        assert should_proceed is True
+        assert "Warning" in msg
+        assert "task-xyz" in msg
+
+    def test_empty_target_id_returns_proceed(self) -> None:
+        assert _validate_target_id_match("", "task-abc", "task", False) == (True, "")
+
+    # --- Wiring tests (CLI integration via CliRunner) ---
+
+    def test_freeze_from_task_mismatch_exits_1(self) -> None:
+        service, repo = _make_service()
+        repo.get_all_frozen_proposals.return_value = []
+        with (_patch_service(service), _mock_from_task("task-abc")):
+            result = runner.invoke(app, ["freeze", "--target-id", "task-xyz", "--from-task", "task-abc"])
+        assert result.exit_code == 1
+        assert "task-xyz" in result.output
+        assert "task-abc" in result.output
+
+    def test_freeze_from_plan_mismatch_exits_1(self) -> None:
+        service, repo = _make_service()
+        repo.get_all_frozen_proposals.return_value = []
+        with (_patch_service(service), _mock_from_plan("plan-111")):
+            result = runner.invoke(app, ["freeze", "--target-id", "plan-222", "--from-plan", "plan-111"])
+        assert result.exit_code == 1
+
+    def test_snapshot_from_task_mismatch_exits_1(self) -> None:
+        service, repo = _make_service()
+        repo.get_active_frozen_proposal.return_value = None
+        repo.get_sealed_verdict.return_value = None
+        repo.is_failed.return_value = False
+        with (_patch_service(service), _mock_from_task("task-abc")):
+            result = runner.invoke(app, ["snapshot-legacy", "--target-id", "task-xyz", "--from-task", "task-abc"])
+        assert result.exit_code == 1
+
+    def test_snapshot_from_plan_mismatch_exits_1(self) -> None:
+        service, repo = _make_service()
+        repo.get_active_frozen_proposal.return_value = None
+        repo.get_sealed_verdict.return_value = None
+        repo.is_failed.return_value = False
+        with (_patch_service(service), _mock_from_plan("plan-111")):
+            result = runner.invoke(app, ["snapshot-legacy", "--target-id", "plan-222", "--from-plan", "plan-111"])
+        assert result.exit_code == 1
+
+    # --- Content-route tests (fixed assertions) ---
+
+    def test_freeze_content_no_guard(self) -> None:
+        service, repo = _make_service()
+        repo.get_all_frozen_proposals.return_value = []
+        with _patch_service(service):
+            result = runner.invoke(app, ["freeze", "--target-id", "anything-at-all", "--content", "data"])
+        assert result.exit_code == 0
+        assert "does not match" not in result.output
+
+    def test_snapshot_content_no_guard(self) -> None:
+        service, repo = _make_service()
+        repo.get_active_frozen_proposal.return_value = None
+        repo.get_sealed_verdict.return_value = None
+        repo.is_failed.return_value = False
+        with _patch_service(service):
+            result = runner.invoke(app, ["snapshot-legacy", "--target-id", "anything-at-all", "--content", "data"])
+        assert result.exit_code == 0
+        assert "does not match" not in result.output

--- a/tests/unit/interfaces/cli/test_fpel_cli.py
+++ b/tests/unit/interfaces/cli/test_fpel_cli.py
@@ -592,7 +592,7 @@ def _mock_from_plan(session_id: str):
 
 
 class TestTargetIdValidation:
-    """10 tests: 4 unit (pure helper), 4 wiring (CLI integration), 2 content-route."""
+    """10 tests: 4 unit (pure helper), 4 wiring (CLI integration), 2 content-route + 2 allow-override wiring."""
 
     # --- Unit tests on pure helper (no mocks needed) ---
 
@@ -659,6 +659,48 @@ class TestTargetIdValidation:
                 app, ["snapshot-legacy", "--target-id", "plan-222", "--from-plan", "plan-111"]
             )
         assert result.exit_code == 1
+
+    # --- Allow-override wiring tests (Copilot review feedback) ---
+
+    def test_freeze_from_task_allow_override_warns_and_proceeds(self) -> None:
+        """freeze --from-task with mismatch + --allow-target-mismatch → exit 0 + Warning."""
+        service, repo = _make_service()
+        repo.get_all_frozen_proposals.return_value = []
+        with _patch_service(service), _mock_from_task("task-abc"):
+            result = runner.invoke(
+                app,
+                [
+                    "freeze",
+                    "--target-id",
+                    "task-xyz",
+                    "--from-task",
+                    "task-abc",
+                    "--allow-target-mismatch",
+                ],
+            )
+        assert result.exit_code == 0
+        assert "Warning" in result.output
+
+    def test_snapshot_from_task_alias_override_warns_and_proceeds(self) -> None:
+        """snapshot-legacy --from-task with mismatch + --allow-target-alias → exit 0 + Warning."""
+        service, repo = _make_service()
+        repo.get_active_frozen_proposal.return_value = None
+        repo.get_sealed_verdict.return_value = None
+        repo.is_failed.return_value = False
+        with _patch_service(service), _mock_from_task("task-abc"):
+            result = runner.invoke(
+                app,
+                [
+                    "snapshot-legacy",
+                    "--target-id",
+                    "task-xyz",
+                    "--from-task",
+                    "task-abc",
+                    "--allow-target-alias",
+                ],
+            )
+        assert result.exit_code == 0
+        assert "Warning" in result.output
 
     # --- Content-route tests (fixed assertions) ---
 


### PR DESCRIPTION
## Summary

- Adds `_validate_target_id_match()` CLI validation helper to prevent accidental `--target-id` mismatches in `freeze` and `snapshot-legacy` commands
- Pure function returns `tuple[bool, str]` — decoupled from `typer.Exit` and `console.print`
- `--allow-target-mismatch` flag (primary) with `--allow-target-alias` hidden alias for backward compatibility
- `logger.warning()` audit trail when mismatch override is used
- `Literal["task", "plan"]` type for `source_type` parameter
- Test suite restructured: 4 unit + 4 wiring + 2 content-route = 10 focused tests

## Design Decisions

| ID | Decision | Rationale |
|----|----------|-----------|
| D30 | `_validate_target_id_match()` pure helper | Returns result, callers handle exit — consistent with `_validate_phase_transition` pattern |
| D31 | `--allow-target-mismatch` primary flag | Clear semantics; hidden `--allow-target-alias` alias for backward compat |
| D32 | `tuple[bool, str]` return type | 3-case problem (match/warning/error) fits cleanly; no exception class needed |
| D33 | Module-level `logging.getLogger(__name__)` | Matches workflow.py and launch.py observability patterns |
| D34 | `Literal["task", "plan"]` for source_type | Prevents typos producing confusing error messages |

## mr-plan Review Findings Addressed

11 findings from 4-agent thorough review (structure + risk + design + simplification):

| Finding | Severity | Fix |
|---------|----------|-----|
| F-1 | HIGH | Restructured test matrix from 12 to 10 focused tests |
| F-2 | MEDIUM | Renamed flag to `--allow-target-mismatch` |
| F-3 | MEDIUM | Unit tests cover all command×route combinations |
| F-4 | MEDIUM | Decoupled helper from `typer.Exit` + `console.print` |
| F-5 | MEDIUM | Fixed weak OR assertion in content-route tests |
| F-6 | MEDIUM | Early return for empty/falsy `target_id` |
| F-7 | MEDIUM | Added `logger.warning()` when override used |
| F-8 | LOW | Same as F-6 (early return) |
| F-9 | LOW | Documented fragile mock import paths |
| F-10 | LOW | Added content-route exclusion comments |
| F-11 | LOW | Added `Literal` type for `source_type` |

## Test Results

- **2812 tests passing**, 107 skipped, 0 failed
- **ruff**: clean
- **mypy**: clean

Closes #51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Freeze and legacy snapshot CLI commands now validate target ID consistency with source identifiers.
  * Added --allow-target-mismatch and --allow-target-alias flags to permit target ID overrides; mismatches now error by default and become warnings when overrides are allowed.
  * The content-based route bypasses the target-ID guard.

* **Tests**
  * Added end-to-end tests covering target ID match, mismatch, override behavior, and the content-route bypass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->