### PR TITLE
feat(fpel): make FPEL default ON (#46)

### DIFF
--- a/src/infrastructure/persistence/container.py
+++ b/src/infrastructure/persistence/container.py
@@ -342,12 +342,12 @@ def get_memory_service_auto():
 
 
 def get_fpel_service(db_path: Path | None = None):
-    """Return wired FPELAuthorizationService when FPEL_ENABLED=1, None when disabled.
+    """Return wired FPELAuthorizationService unless FPEL_DISABLED=1, None when disabled.
 
     Raises:
         RuntimeError: On container init failure when FPEL is enabled.
     """
-    if os.environ.get("FPEL_ENABLED", "").strip() != "1":
+    if os.environ.get("FPEL_DISABLED", "").strip() == "1":
         return None
     return get_container(db_path).fpel_authorization_service()
 

--- a/src/interfaces/cli/commands/fpel.py
+++ b/src/interfaces/cli/commands/fpel.py
@@ -32,7 +32,7 @@ def seal_failure_exit_code(reason: SealFailureReason) -> int:
 def _get_fpel_service():
     """Build FPELAuthorizationService via infrastructure container.
 
-    Returns None when FPEL_ENABLED is not set — callers must handle this.
+    Returns None when FPEL is disabled via FPEL_DISABLED=1 — callers must handle this.
     """
     from src.infrastructure.persistence.container import get_fpel_service
 
@@ -43,7 +43,7 @@ def _require_fpel_service():
     """Get FPEL service or exit with error if FPEL is disabled."""
     service = _get_fpel_service()
     if service is None:
-        console.print("[red]Error: FPEL is disabled. Set FPEL_ENABLED=1 to enable.[/red]")
+        console.print("[red]Error: FPEL is disabled via FPEL_DISABLED=1.[/red]")
         raise typer.Exit(1)
     return service
 

--- a/src/interfaces/cli/commands/workflow.py
+++ b/src/interfaces/cli/commands/workflow.py
@@ -54,7 +54,7 @@ logger = logging.getLogger(__name__)
 def get_fpel_authorization_port():
     """Get the FPELAuthorizationPort instance.
 
-    Returns FPELAuthorizationService when FPEL_ENABLED=1.
+    Returns FPELAuthorizationService unless FPEL_DISABLED=1.
     Returns None when FPEL is disabled.
     Raises RuntimeError on container init failure (never silently returns None when enabled).
     """

--- a/tests/integration/test_fpel_fail_roundtrip.py
+++ b/tests/integration/test_fpel_fail_roundtrip.py
@@ -153,7 +153,8 @@ class TestTransitiveCoverage:
         )
         run_migrations(config, migrations_dir)
 
-        with patch.dict(os.environ, {"FPEL_ENABLED": "1"}):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("FPEL_DISABLED", None)
             task_board = get_task_board_service(db_path=db_path)
 
             task = task_board.create(subject="Transitive test task")
@@ -190,9 +191,7 @@ class TestTransitiveCoverage:
         service.mark_fail(target_id="workflow-target", reason="workflow fail test")
 
         # Simulate what workflow execute does: call check_sealed via the FPEL service
-        with patch.dict(
-            os.environ, {"FPEL_ENABLED": "1", "DB_PATH": str(tmp_path / "fpel_fail_integration.db")}
-        ):
+        with patch.dict(os.environ, {"DB_PATH": str(tmp_path / "fpel_fail_integration.db")}):
             fpel_port = get_fpel_service(db_path=tmp_path / "fpel_fail_integration.db")
 
         assert fpel_port is not None

--- a/tests/integration/test_fpel_fail_roundtrip.py
+++ b/tests/integration/test_fpel_fail_roundtrip.py
@@ -191,7 +191,10 @@ class TestTransitiveCoverage:
         service.mark_fail(target_id="workflow-target", reason="workflow fail test")
 
         # Simulate what workflow execute does: call check_sealed via the FPEL service
-        with patch.dict(os.environ, {"DB_PATH": str(tmp_path / "fpel_fail_integration.db")}):
+        with patch.dict(
+            os.environ, {"DB_PATH": str(tmp_path / "fpel_fail_integration.db")}, clear=False
+        ):
+            os.environ.pop("FPEL_DISABLED", None)
             fpel_port = get_fpel_service(db_path=tmp_path / "fpel_fail_integration.db")
 
         assert fpel_port is not None

--- a/tests/integration/test_fpel_wiring.py
+++ b/tests/integration/test_fpel_wiring.py
@@ -1,8 +1,8 @@
 """Integration tests for FPEL runtime wiring — Phase 3.
 
 Tests:
-- Fail-closed: FPEL_ENABLED=1, no sealed PASS → TaskTransitionError
-- Fail-open: FPEL_ENABLED unset → task transitions succeed without FPEL gate
+- Fail-closed: FPEL enabled (default), no sealed PASS → TaskTransitionError
+- Fail-open: FPEL_DISABLED=1 → task transitions succeed without FPEL gate
 """
 
 from __future__ import annotations
@@ -36,12 +36,13 @@ def _setup_db(tmp_path: Path) -> Path:
 
 
 class TestFailClosedDeniesWithoutSealedPass:
-    """FPEL_ENABLED=1 + no sealed PASS → start() denied."""
+    """FPEL enabled by default + no sealed PASS → start() denied."""
 
     def test_fail_closed_denies_without_sealed_pass(self, tmp_path: Path) -> None:
         db_path = _setup_db(tmp_path)
 
-        with patch.dict(os.environ, {"FPEL_ENABLED": "1"}):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("FPEL_DISABLED", None)
             service = get_task_board_service(db_path=db_path)
 
             task = service.create(subject="FPEL integration test")
@@ -53,13 +54,12 @@ class TestFailClosedDeniesWithoutSealedPass:
 
 
 class TestFailOpenWhenDisabled:
-    """FPEL_ENABLED unset → task transitions succeed without FPEL gate."""
+    """FPEL_DISABLED=1 → task transitions succeed without FPEL gate."""
 
     def test_fail_open_when_disabled(self, tmp_path: Path) -> None:
         db_path = _setup_db(tmp_path)
 
-        with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("FPEL_ENABLED", None)
+        with patch.dict(os.environ, {"FPEL_DISABLED": "1"}):
             service = get_task_board_service(db_path=db_path)
 
             task = service.create(subject="FPEL disabled test")

--- a/tests/unit/infrastructure/test_container.py
+++ b/tests/unit/infrastructure/test_container.py
@@ -161,25 +161,25 @@ class TestGetFpelService:
     """Tests for get_fpel_service() factory function."""
 
     def test_get_fpel_service_returns_service(self, tmp_path: Path) -> None:
-        """FPEL_ENABLED=1 → get_fpel_service() returns wired FPELAuthorizationService."""
+        """FPEL enabled by default → get_fpel_service() returns wired FPELAuthorizationService."""
         from src.application.services.fpel_authorization_service import FPELAuthorizationService
         from src.infrastructure.persistence.container import get_fpel_service
 
         db_path = tmp_path / "fpel_factory_test.db"
 
-        with patch.dict(os.environ, {"FPEL_ENABLED": "1"}):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("FPEL_DISABLED", None)
             service = get_fpel_service(db_path=db_path)
 
         assert isinstance(service, FPELAuthorizationService)
 
     def test_get_fpel_service_returns_none_when_disabled(self, tmp_path: Path) -> None:
-        """FPEL_ENABLED unset → get_fpel_service() returns None."""
+        """FPEL_DISABLED=1 → get_fpel_service() returns None."""
         from src.infrastructure.persistence.container import get_fpel_service
 
         db_path = tmp_path / "fpel_disabled_test.db"
 
-        with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("FPEL_ENABLED", None)
+        with patch.dict(os.environ, {"FPEL_DISABLED": "1"}):
             service = get_fpel_service(db_path=db_path)
 
         assert service is None
@@ -189,14 +189,15 @@ class TestGetTaskBoardServiceFPELInjection:
     """Tests for get_task_board_service() fpel_port injection."""
 
     def test_get_task_board_service_has_fpel_port(self, tmp_path: Path) -> None:
-        """FPEL_ENABLED=1 → TaskBoardService receives fpel_port != None."""
+        """FPEL enabled by default → TaskBoardService receives fpel_port != None."""
         from src.infrastructure.persistence.container import (
             get_task_board_service,
         )
 
         db_path = tmp_path / "fpel_injection_test.db"
 
-        with patch.dict(os.environ, {"FPEL_ENABLED": "1"}):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("FPEL_DISABLED", None)
             service = get_task_board_service(db_path=db_path)
 
         assert service._fpel_port is not None

--- a/tests/unit/interfaces/cli/commands/test_workflow.py
+++ b/tests/unit/interfaces/cli/commands/test_workflow.py
@@ -77,6 +77,9 @@ class TestWorkflowExecute:
         plan_path = tmp_path / "plan-state.json"
         plan_state.save(plan_path)
 
+        mock_fpel_port = MagicMock()
+        mock_fpel_port.check_sealed.return_value = MagicMock(allowed=True)
+
         with (
             patch(
                 "src.interfaces.cli.commands.workflow.get_plan_state_path",
@@ -85,6 +88,10 @@ class TestWorkflowExecute:
             patch(
                 "src.interfaces.cli.commands.workflow.get_execute_state_path",
                 return_value=tmp_path / "execute-state.json",
+            ),
+            patch(
+                "src.interfaces.cli.commands.workflow.get_fpel_authorization_port",
+                return_value=mock_fpel_port,
             ),
         ):
             result = runner.invoke(get_app(), ["execute"])
@@ -902,7 +909,7 @@ class TestGetFpelAuthorizationPortFailClosed:
                 "src.infrastructure.persistence.container.get_container",
                 side_effect=RuntimeError("DB connection failed"),
             ),
-            patch.dict("os.environ", {"FPEL_ENABLED": "1"}),
+            patch.dict("os.environ", {}, clear=False),
             pytest.raises(
                 (RuntimeError, Exception),
             ),

--- a/tests/unit/interfaces/cli/test_fpel_cli.py
+++ b/tests/unit/interfaces/cli/test_fpel_cli.py
@@ -387,37 +387,33 @@ class TestSealFailureExitCodes:
 
 
 class TestFpelDisabledGracefulExit:
-    """When FPEL_ENABLED is unset, CLI commands must exit with error, not crash."""
+    """When FPEL_DISABLED=1, CLI commands must exit with error, not crash."""
 
     def test_freeze_exits_when_disabled(self) -> None:
         """freeze command exits with code 1 when FPEL is disabled."""
-        with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("FPEL_ENABLED", None)
+        with patch.dict(os.environ, {"FPEL_DISABLED": "1"}):
             result = runner.invoke(app, ["freeze", "--target-id", "t1", "--content", "x"])
 
         assert result.exit_code == 1
-        assert "disabled" in result.output.lower() or "FPEL_ENABLED" in result.output
+        assert "disabled" in result.output.lower()
 
     def test_seal_exits_when_disabled(self) -> None:
         """seal command exits with code 1 when FPEL is disabled."""
-        with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("FPEL_ENABLED", None)
+        with patch.dict(os.environ, {"FPEL_DISABLED": "1"}):
             result = runner.invoke(app, ["seal", "--target-id", "t1"])
 
         assert result.exit_code == 1
 
     def test_status_exits_when_disabled(self) -> None:
         """status command exits with code 1 when FPEL is disabled."""
-        with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("FPEL_ENABLED", None)
+        with patch.dict(os.environ, {"FPEL_DISABLED": "1"}):
             result = runner.invoke(app, ["status", "--target-id", "t1"])
 
         assert result.exit_code == 1
 
     def test_check_exits_when_disabled(self) -> None:
         """check command exits with code 1 when FPEL is disabled."""
-        with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("FPEL_ENABLED", None)
+        with patch.dict(os.environ, {"FPEL_DISABLED": "1"}):
             result = runner.invoke(app, ["check", "--target-id", "t1"])
 
         assert result.exit_code == 1


### PR DESCRIPTION
## Summary

- Flips FPEL from opt-in (`FPEL_ENABLED=1`) to opt-out (`FPEL_DISABLED=1`)
- FPEL authorization gates are now **active by default**
- Single-line production change in `container.py` + mechanical test refactor

## Context

FPEL rollout is complete. All prerequisite features are merged:
- #43: Runtime wiring foundation (opt-in)
- #48: Hash authority
- #49: FAIL terminal state
- #50: Legacy APPROVED snapshot
- #51: Target-id mismatch guard

The opt-in period served its purpose. Time to enforce by default.

## Changes

### Production (3 files)
| File | Change |
|------|--------|
| `container.py` | Guard flipped: `FPEL_DISABLED == "1"` → returns None |
| `fpel.py` | Error message: "FPEL is disabled via FPEL_DISABLED=1" |
| `workflow.py` | Docstring updated |

### Tests (5 files, 26 refs updated)
| File | Change |
|------|--------|
| `test_container.py` | FPEL_ENABLED → FPEL_DISABLED with inverted logic |
| `test_fpel_cli.py` | Same |
| `test_fpel_wiring.py` | Same |
| `test_fpel_fail_roundtrip.py` | Removed FPEL_ENABLED (default ON) |
| `test_workflow.py` | Same |

### Migration Notes
- **Existing users** without `FPEL_ENABLED` set will now have FPEL gates **active**
- To disable: set `FPEL_DISABLED=1` in environment
- Old `FPEL_ENABLED=1` is no longer checked — no effect

## Verification

- **2814 tests passing**, 107 skipped
- **ruff**: clean
- **mypy**: clean
- **0 `FPEL_ENABLED` references** remaining (verified via rg)

Closes #46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated FPEL authorization service error messages and documentation to reflect new configuration approach. FPEL is now controlled via the `FPEL_DISABLED` environment variable: set it to `1` to disable the service; otherwise it runs by default.

* **Chores**
  * Updated integration and unit tests to reflect the new FPEL configuration semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->